### PR TITLE
Added option for default transmit source name

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -43,6 +43,7 @@
 #define MAX_SACN_TRANSMIT_TIME_SEC  1000000
 
 #define DEFAULT_SOURCE_NAME "sACNView"
+#define MAX_SOURCE_NAME_LEN 63
 
 
 enum PriorityMode

--- a/src/multiuniverse.cpp
+++ b/src/multiuniverse.cpp
@@ -64,8 +64,12 @@ void MultiUniverse::on_btnAddRow_pressed()
     m_fxEngines.last()->setEndAddress(MAX_DMX_ADDRESS-1);
     m_fxEngines.last()->setMode(sACNEffectEngine::FxManual);
     m_fxEngines.last()->start();
-    m_senders.last()->setName(tr("sACNView_%1").arg(nextUniverse));
-
+    {
+        QString name = Preferences::getInstance()->GetDefaultTransmitName();
+        QString postfix = tr("_%1").arg(nextUniverse);
+        name.truncate(MAX_SOURCE_NAME_LEN - postfix.length());
+        m_senders.last()->setName(name.trimmed() + postfix);
+    }
 
     QCheckBox *enableBox = new QCheckBox(this);
     enableBox->setStyleSheet("margin-left:50%; margin-right:50%;");

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -107,7 +107,8 @@ void Preferences::SetBlindVisualizer (bool bBlindVisualizer)
 
 void Preferences::SetDefaultTransmitName (QString sDefaultTransmitName)
 {
-    m_sDefaultTransmitName = sDefaultTransmitName;
+    sDefaultTransmitName.truncate(MAX_SOURCE_NAME_LEN);
+    m_sDefaultTransmitName = sDefaultTransmitName.trimmed();
     return;
 }
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -105,6 +105,12 @@ void Preferences::SetBlindVisualizer (bool bBlindVisualizer)
     return;
 }
 
+void Preferences::SetDefaultTransmitName (QString sDefaultTransmitName)
+{
+    m_sDefaultTransmitName = sDefaultTransmitName;
+    return;
+}
+
 void Preferences::SetNumSecondsOfSacn (int nNumSecondsOfSacn)
 {
     Q_ASSERT(nNumSecondsOfSacn >= 0 && nNumSecondsOfSacn <= MAX_SACN_TRANSMIT_TIME_SEC);
@@ -129,6 +135,11 @@ bool Preferences::GetBlindVisualizer()
     return m_bBlindVisualizer;
 }
 
+QString Preferences::GetDefaultTransmitName()
+{
+   return m_sDefaultTransmitName;
+}
+
 unsigned int Preferences::GetNumSecondsOfSacn()
 {
    return m_nNumSecondsOfSacn;
@@ -147,6 +158,7 @@ void Preferences::savePreferences()
         settings.setValue(S_MAC_ADDRESS, m_interface.hardwareAddress());
     settings.setValue(S_DISPLAY_FORMAT, QVariant(m_nDisplayFormat));
     settings.setValue(S_BLIND_VISUALIZER, QVariant(m_bBlindVisualizer));
+    settings.setValue(S_DEFAULT_SOURCENAME, m_sDefaultTransmitName);
     settings.setValue(S_TIMEOUT, QVariant(m_nNumSecondsOfSacn));
     settings.setValue(S_FLICKERFINDERSHOWINFO, QVariant(m_flickerFinderShowInfo));
 }
@@ -166,6 +178,7 @@ void Preferences::loadPreferences()
 
     m_nDisplayFormat = settings.value(S_DISPLAY_FORMAT, QVariant(DECIMAL)).toInt();
     m_bBlindVisualizer = settings.value(S_BLIND_VISUALIZER, QVariant(false)).toBool();
+    m_sDefaultTransmitName = settings.value(S_DEFAULT_SOURCENAME, DEFAULT_SOURCE_NAME).toString();
     m_nNumSecondsOfSacn = settings.value(S_TIMEOUT, QVariant(0)).toInt();
     m_flickerFinderShowInfo = settings.value(S_FLICKERFINDERSHOWINFO, QVariant(true)).toBool();
 }

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -29,6 +29,7 @@
 static const QString S_MAC_ADDRESS("MacAddress");
 static const QString S_DISPLAY_FORMAT("Display Format");
 static const QString S_BLIND_VISUALIZER("Show Blind");
+static const QString S_DEFAULT_SOURCENAME("Default Transmit Source Name");
 static const QString S_TIMEOUT("Timeout");
 static const QString S_FLICKERFINDERSHOWINFO("Flicker Finder Info");
 
@@ -70,12 +71,14 @@ public:
     // Preferences access functions here:
     void SetDisplayFormat(unsigned int nDisplayFormat);
     void SetBlindVisualizer (bool bBlindVisualizer);
+    void SetDefaultTransmitName (QString sDefaultTransmitName);
     void SetNumSecondsOfSacn (int nNumSecondsOfSacn);
     void setFlickerFinderShowInfo(bool showIt);
 
     unsigned int GetDisplayFormat();
     unsigned int GetMaxLevel();
     bool GetBlindVisualizer();
+    QString Preferences::GetDefaultTransmitName();
     unsigned int GetNumSecondsOfSacn();
     bool getFlickerFinderShowInfo();
 
@@ -96,6 +99,7 @@ private:
 
     unsigned int m_nDisplayFormat;
     bool m_bBlindVisualizer;
+    QString m_sDefaultTransmitName;
     unsigned int m_nNumSecondsOfSacn;
     bool m_flickerFinderShowInfo;
 

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -114,11 +114,7 @@ void PreferencesDialog::on_buttonBox_accepted()
         seconds = 0;
     p->SetNumSecondsOfSacn(seconds);
 
-    {
-        QString name = ui->leDefaultSourceName->text();
-        name.truncate(MAX_SOURCE_NAME_LEN);
-        p->SetDefaultTransmitName(name);
-    }
+    p->SetDefaultTransmitName(ui->leDefaultSourceName->text());
 
     for(int i=0; i<m_interfaceButtons.count(); i++)
     {

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -69,6 +69,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
 
     ui->cbDisplayBlind->setChecked(Preferences::getInstance()->GetBlindVisualizer());
 
+    ui->leDefaultSourceName->setText(Preferences::getInstance()->GetDefaultTransmitName());
+
     int timeout = Preferences::getInstance()->GetNumSecondsOfSacn();
     if(timeout>0)
     {
@@ -111,6 +113,12 @@ void PreferencesDialog::on_buttonBox_accepted()
     if(!ui->gbTransmitTimeout->isChecked())
         seconds = 0;
     p->SetNumSecondsOfSacn(seconds);
+
+    {
+        QString name = ui->leDefaultSourceName->text();
+        name.truncate(MAX_SOURCE_NAME_LEN);
+        p->SetDefaultTransmitName(name);
+    }
 
     for(int i=0; i<m_interfaceButtons.count(); i++)
     {

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -3,6 +3,7 @@
 #include "consts.h"
 #include "sacnlistener.h"
 #include "sacnsender.h"
+#include "preferences.h"
 #include <QTimer>
 #include <QSound>
 #include <QSpinBox>
@@ -185,7 +186,12 @@ void Snapshot::playSnapshot()
     {
         m_senders << new sACNSentUniverse(m_universeSpins[i]->value());
 
-        m_senders.last()->setName(tr("sACNView Snapshot"));
+        {
+            QString name = Preferences::getInstance()->GetDefaultTransmitName();
+            QString postfix = tr(" - Snapshot");
+            name.truncate(MAX_SOURCE_NAME_LEN - postfix.length());
+            m_senders.last()->setName(name.trimmed() + postfix);
+        }
 
         m_senders.last()->startSending();
         m_senders.last()->setLevel((const quint8*)m_snapshotData[i].constData(), MAX_DMX_ADDRESS);

--- a/src/transmitwindow.cpp
+++ b/src/transmitwindow.cpp
@@ -52,7 +52,7 @@ transmitwindow::transmitwindow(QWidget *parent) :
     ui->sbFadeRangeStart->setMinimum(MIN_DMX_ADDRESS);
     ui->sbFadeRangeStart->setMaximum(MAX_DMX_ADDRESS);
 
-    ui->leSourceName->setText(DEFAULT_SOURCE_NAME);
+    ui->leSourceName->setText(Preferences::getInstance()->GetDefaultTransmitName());
 
     ui->dlFadeRate->setMinimum(0);
     ui->dlFadeRate->setMaximum(FX_FADE_RATES.count()-1);

--- a/ui/preferencesdialog.ui
+++ b/ui/preferencesdialog.ui
@@ -7,8 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>354</height>
+    <height>500</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>400</width>
+    <height>500</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Preferences</string>
@@ -27,6 +39,12 @@
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Display Format</string>
      </property>
@@ -60,12 +78,36 @@
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>50</height>
+      </size>
+     </property>
      <property name="title">
       <string>Recieve Options</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QCheckBox" name="cbDisplayBlind">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>30</height>
+         </size>
+        </property>
         <property name="text">
          <string>Display Blind/Visualizer Data</string>
         </property>
@@ -75,70 +117,121 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbTransmitTimeout">
+    <widget class="QGroupBox" name="gbTransmitOptions">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>170</height>
+      </size>
+     </property>
      <property name="title">
-      <string>Stop transmitting sACN after</string>
+      <string>Transmit Options</string>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
-        </property>
-        <item>
-         <widget class="QSpinBox" name="NumOfHoursOfSacn">
-          <property name="maximum">
-           <number>48</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Hours</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="NumOfMinOfSacn">
-          <property name="maximum">
-           <number>500</number>
-          </property>
-          <property name="value">
-           <number>5</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Minutes</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="NumOfSecOfSacn">
-          <property name="maximum">
-           <number>100000</number>
-          </property>
-          <property name="value">
-           <number>0</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Seconds</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
+     <widget class="QGroupBox" name="gbTransmitTimeout">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>85</y>
+        <width>361</width>
+        <height>73</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Stop transmitting sACN after</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <item>
+          <widget class="QSpinBox" name="NumOfHoursOfSacn">
+           <property name="maximum">
+            <number>48</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Hours</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="NumOfMinOfSacn">
+           <property name="maximum">
+            <number>500</number>
+           </property>
+           <property name="value">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Minutes</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="NumOfSecOfSacn">
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Seconds</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QGroupBox" name="gbTransmitName">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>361</width>
+        <height>55</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Default Source Name</string>
+      </property>
+      <widget class="QLineEdit" name="leDefaultSourceName">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>341</width>
+         <height>25</height>
+        </rect>
+       </property>
+       <property name="maxLength">
+        <number>63</number>
+       </property>
+      </widget>
+     </widget>
     </widget>
    </item>
    <item>

--- a/ui/transmitwindow.ui
+++ b/ui/transmitwindow.ui
@@ -164,7 +164,11 @@ border-radius: 4px;
         </widget>
        </item>
        <item row="0" column="1" colspan="2">
-        <widget class="QLineEdit" name="leSourceName"/>
+        <widget class="QLineEdit" name="leSourceName">
+         <property name="maxLength">
+          <number>63</number>
+         </property>
+        </widget>
        </item>
        <item row="3" column="1" colspan="2">
         <widget class="QComboBox" name="cbPriorityMode">


### PR DESCRIPTION
A Default transmit source name can be added from the preferences dialog.
This is utilised in full by the transmit window and used as a basis for the multiuniverse and snapshot windows.