### PR TITLE
Generate AppImage on Travis CI and upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 
 after_success:
   - FILE=$(readlink -f install/linux/sACNView_*AppImage)
-  - curl --upload-file .$FILE https://transfer.sh/$(basename $FILE)
+  - curl --upload-file $FILE https://transfer.sh/$(basename $FILE)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 script:
   - qmake
   - make -j$(nproc) || true # Errors out but at that point the AppImage has already been generated
+  # Interestingly, the whole linuxdeployqt handling is done in the .pro file
 
 after_success:
   - FILE=$(readlink -f install/linux/sACNView_*AppImage)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt59base
+    - sudo apt-get -y install qt59base qt59multimedia
     - source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,8 @@ install:
 script:
   - qmake PREFIX=/usr
   - make -j$(nproc)
-  - make INSTALL_ROOT=appdir install ; find appdir/
+  - make INSTALL_ROOT=appdir install
 
 after_success:
-  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
-  - chmod a+x linuxdeployqt*.AppImage
-  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
-  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./sACNView*.AppImage https://transfer.sh/sACNView-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - FILE=$(readlink -f install/linux/sACNView_*AppImage)
+  - curl --upload-file .$FILE https://transfer.sh/$(basename $FILE)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - qmake
-  - make -j$(nproc)
+  - make -j$(nproc) || true # Errors out but at that point the AppImage has already been generated
 
 after_success:
   - FILE=$(readlink -f install/linux/sACNView_*AppImage)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ install:
     - source /opt/qt*/bin/qt*-env.sh
 
 script:
-  - qmake PREFIX=/usr
+  - qmake
   - make -j$(nproc)
-  - make INSTALL_ROOT=appdir install
 
 after_success:
   - FILE=$(readlink -f install/linux/sACNView_*AppImage)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt59base
+    - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j$(nproc)
+  - make INSTALL_ROOT=appdir install ; find appdir/
+
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./sACNView*.AppImage https://transfer.sh/sACNView-git.$(git rev-parse --short HEAD)-x86_64.AppImage


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.