### PR TITLE
Treat per-address priority 0 as unpatched

### DIFF
--- a/src/sacn/sacnlistener.cpp
+++ b/src/sacn/sacnlistener.cpp
@@ -551,12 +551,11 @@ void sACNListener::performMerge()
 
     QMultiMap<int, sACNSource*> addressToSourceMap;
 
-
+	// Find the highest priority for the address
     for(std::vector<sACNSource *>::iterator it = m_sources.begin(); it != m_sources.end(); ++it)
     {
         sACNSource *ps = *it;
-
-        // Find the highest priority for the address, ignoring priorities of zero
+ 
         if(ps->src_valid && !ps->active.Expired() && !ps->doing_per_channel)
         {
             // Set the priority array for sources which are not doing per-channel
@@ -573,17 +572,21 @@ void sACNListener::performMerge()
             sACNMergedAddress *pAddr = &m_merged_levels[addresses_to_merge[i]];
             int address = addresses_to_merge[i];
 
-            if (ps->src_valid  && !ps->active.Expired() && ps->priority_array[address] > priorities[address])
-            {
-                // Sources of higher priority
-                priorities[address] = ps->priority_array[address];
-                addressToSourceMap.remove(address);
-                addressToSourceMap.insert(address, ps);
-            }
-            if (ps->src_valid  && !ps->active.Expired() && ps->priority_array[address] == priorities[address])
-            {
-                addressToSourceMap.insert(address, ps);
-            }
+			if (
+					ps->src_valid // Valid Source
+					&& !(ps->priority_array[address] < priorities[address]) // Not lesser priority
+					&& ( (ps->priority_array[address] > 0) || (ps->priority_array[address] == 0 && !ps->doing_per_channel) ) // Priority > 0 if DD
+				)
+			{
+				if (ps->priority_array[address] > priorities[address])
+				{
+					// Source of higher priority
+					priorities[address] = ps->priority_array[address];
+					addressToSourceMap.remove(address);
+				}
+				addressToSourceMap.insert(address, ps);
+			}
+
             if(ps->src_valid && !ps->active.Expired())
                 pAddr->otherSources << ps;
         }

--- a/src/sacn/streamingacn.cpp
+++ b/src/sacn/streamingacn.cpp
@@ -52,8 +52,8 @@ sACNSource::sACNSource()
     doing_per_channel = false;  //If true, we are tracking per-channel priority messages for this source
     isPreview = false;
     universe = 0;
-    memset(level_array, -1, 512);
-    memset(priority_array, -1, 512);
+    std::fill(level_array, level_array + sizeof(level_array), 0);
+    std::fill(priority_array, priority_array + sizeof(priority_array), 0);
     priority = 0;
     fpsTimer.start();
     fpsCounter = 0;


### PR DESCRIPTION
Alternate Startcode “DD” per-address stipulates that an address priority of 0 is unpatched. 
So don't merge addresses at priority 0.