### PR TITLE
Display sources that only send 0xdd

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -107,6 +107,13 @@ void Preferences::SetBlindVisualizer (bool bBlindVisualizer)
     return;
 }
 
+void Preferences::SetDisplayDDOnly(bool bDDOnly)
+{
+    Q_ASSERT(bDDOnly == 0 || bDDOnly == 1);
+    m_bDisplayDDOnly = bDDOnly;
+    return;
+}
+
 void Preferences::SetDefaultTransmitName (QString sDefaultTransmitName)
 {
     sDefaultTransmitName.truncate(MAX_SOURCE_NAME_LEN);
@@ -138,6 +145,11 @@ bool Preferences::GetBlindVisualizer()
     return m_bBlindVisualizer;
 }
 
+bool Preferences::GetDisplayDDOnly()
+{
+    return m_bDisplayDDOnly;
+}
+
 QString Preferences::GetDefaultTransmitName()
 {
    return m_sDefaultTransmitName;
@@ -161,6 +173,7 @@ void Preferences::savePreferences()
         settings.setValue(S_MAC_ADDRESS, m_interface.hardwareAddress());
     settings.setValue(S_DISPLAY_FORMAT, QVariant(m_nDisplayFormat));
     settings.setValue(S_BLIND_VISUALIZER, QVariant(m_bBlindVisualizer));
+    settings.setValue(S_DDONLY, QVariant(m_bDisplayDDOnly));
     settings.setValue(S_DEFAULT_SOURCENAME, m_sDefaultTransmitName);
     settings.setValue(S_TIMEOUT, QVariant(m_nNumSecondsOfSacn));
     settings.setValue(S_FLICKERFINDERSHOWINFO, QVariant(m_flickerFinderShowInfo));
@@ -197,6 +210,7 @@ void Preferences::loadPreferences()
 
     m_nDisplayFormat = settings.value(S_DISPLAY_FORMAT, QVariant(DECIMAL)).toInt();
     m_bBlindVisualizer = settings.value(S_BLIND_VISUALIZER, QVariant(true)).toBool();
+    m_bDisplayDDOnly = settings.value(S_DDONLY, QVariant(true)).toBool();
     m_sDefaultTransmitName = settings.value(S_DEFAULT_SOURCENAME, DEFAULT_SOURCE_NAME).toString();
     m_nNumSecondsOfSacn = settings.value(S_TIMEOUT, QVariant(0)).toInt();
     m_flickerFinderShowInfo = settings.value(S_FLICKERFINDERSHOWINFO, QVariant(true)).toBool();

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -30,6 +30,7 @@
 static const QString S_MAC_ADDRESS("MacAddress");
 static const QString S_DISPLAY_FORMAT("Display Format");
 static const QString S_BLIND_VISUALIZER("Show Blind");
+static const QString S_DDONLY("Show DDOnly");
 static const QString S_DEFAULT_SOURCENAME("Default Transmit Source Name");
 static const QString S_TIMEOUT("Timeout");
 static const QString S_FLICKERFINDERSHOWINFO("Flicker Finder Info");
@@ -84,6 +85,7 @@ public:
     // Preferences access functions here:
     void SetDisplayFormat(unsigned int nDisplayFormat);
     void SetBlindVisualizer (bool bBlindVisualizer);
+    void SetDisplayDDOnly (bool bDDOnly);
     void SetDefaultTransmitName (QString sDefaultTransmitName);
     void SetNumSecondsOfSacn (int nNumSecondsOfSacn);
     void setFlickerFinderShowInfo(bool showIt);
@@ -95,6 +97,7 @@ public:
     unsigned int GetDisplayFormat();
     unsigned int GetMaxLevel();
     bool GetBlindVisualizer();
+    bool GetDisplayDDOnly();
     QString GetDefaultTransmitName();
     unsigned int GetNumSecondsOfSacn();
     bool getFlickerFinderShowInfo();
@@ -121,6 +124,7 @@ private:
 
     unsigned int m_nDisplayFormat;
     bool m_bBlindVisualizer;
+    bool m_bDisplayDDOnly;
     QString m_sDefaultTransmitName;
     unsigned int m_nNumSecondsOfSacn;
     bool m_flickerFinderShowInfo;

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -68,6 +68,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
     }
 
     ui->cbDisplayBlind->setChecked(Preferences::getInstance()->GetBlindVisualizer());
+    ui->cbDisplayDDOnlys->setChecked(Preferences::getInstance()->GetDisplayDDOnly());
     ui->cbRestoreWindows->setChecked(Preferences::getInstance()->GetSaveWindowLayout());
 
     ui->leDefaultSourceName->setText(Preferences::getInstance()->GetDefaultTransmitName());
@@ -98,6 +99,8 @@ PreferencesDialog::~PreferencesDialog()
 
 void PreferencesDialog::on_buttonBox_accepted()
 {
+    bool requiresRestart = false;
+
     Preferences *p = Preferences::getInstance();
     int displayFormat=0;
     if(ui->DecimalDisplayFormat->isChecked())
@@ -109,6 +112,10 @@ void PreferencesDialog::on_buttonBox_accepted()
 
     p->SetDisplayFormat(displayFormat);
     p->SetBlindVisualizer(ui->cbDisplayBlind->isChecked());
+
+    if (ui->cbDisplayDDOnlys->isChecked() != p->GetDisplayDDOnly() ) {requiresRestart = true;}
+    p->SetDisplayDDOnly(ui->cbDisplayDDOnlys->isChecked());
+
     p->SetSaveWindowLayout(ui->cbRestoreWindows->isChecked());
 
     int seconds = ui->NumOfHoursOfSacn->value()*60*60 + ui->NumOfMinOfSacn->value()*60 + ui->NumOfSecOfSacn->value();
@@ -127,13 +134,18 @@ void PreferencesDialog::on_buttonBox_accepted()
             {
                 p->setNetworkInterface(m_interfaceList[i]);
 
-                QMessageBox::information(this, tr("Network Interface Changed"),
-                                         tr("After changing the network interface, you will need to restart the application. sACNView will now close and restart"),
-                                         QMessageBox::Ok);
-                p->RESTART_APP = true;
-                qApp->quit();
+                requiresRestart = true;
 
+                break;
             }
         }
+    }
+
+    if (requiresRestart) {
+        QMessageBox::information(this, tr("Restart requied"),
+                                 tr("To apply these preferences, you will need to restart the application. \nsACNView will now close and restart"),
+                                 QMessageBox::Ok);
+        p->RESTART_APP = true;
+        qApp->quit();
     }
 }

--- a/src/sacn/sacnlistener.cpp
+++ b/src/sacn/sacnlistener.cpp
@@ -110,7 +110,7 @@ void sACNListener::checkSourceExpiration()
     {
         if((*it)->src_valid)
         {
-            if((*it)->active.Expired())
+            if((*it)->active.Expired() && (*it)->priority_wait.Expired())
             {
                 (*it)->src_valid = false;
                 CID::CIDIntoString((*it)->src_cid, cidstr);
@@ -291,7 +291,11 @@ void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHost
             //if we've never seen a dmx packet from the source.
             if(!(*it)->doing_dmx)
             {
-                validpacket = false;
+                /* For fault finding an installation which only sends 0xdd for a universe
+                 * (For example: ETC Cobalt does this for, currenlty, unpatched universes with in it's network map)
+                 * We do want to say that having not sent dimmer data is a valid source/packet
+                 */
+                // validpacket = false;
                 (*it)->priority_wait.Reset();  //We don't want to let the priority timer run out
             }
             else if(!(*it)->waited_for_dd && validpacket)
@@ -438,6 +442,25 @@ void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHost
         }
         else if(start_code == STARTCODE_PRIORITY)
         {
+            // Not sending DMX data, so process name and FPS
+            if (ps->doing_dmx == false) {
+
+                if(ps->name!=name)
+                {
+                    ps->name = name;
+                    ps->source_params_change = true;
+                }
+
+                if(ps->fpsTimer.elapsed() >= 1000)
+                {
+                    // Calculate the FPS rate
+                    ps->fpsTimer.restart();
+                    ps->fps = ps->fpsCounter;
+                    ps->fpsCounter = 0;
+                    ps->source_params_change = true;
+                }
+            }
+
             // Copy the last array back
             memcpy(ps->last_priority_array, ps->priority_array, 512);
             // Fill in the new array

--- a/src/sacn/sacnuniverselistmodel.cpp
+++ b/src/sacn/sacnuniverselistmodel.cpp
@@ -45,6 +45,8 @@ sACNUniverseListModel::sACNUniverseListModel(QObject *parent) : QAbstractItemMod
 {
     m_start = MIN_SACN_UNIVERSE;
 
+    m_displayDDOnlySource = Preferences::getInstance()->GetDisplayDDOnly();
+
     setStartUniverse(m_start);
 }
 
@@ -164,6 +166,9 @@ void sACNUniverseListModel::sourceOnline(sACNSource *source)
             (univIndex < 0)
         ) { return; }
 
+    // Display sources that only transmit 0xdd?
+    if (!m_displayDDOnlySource && !source->doing_dmx) { return; }
+
     // Create sACNBasicSourceInfo copy of sACNSource
     sACNBasicSourceInfo *info = Q_NULLPTR;
     info = new sACNBasicSourceInfo(m_universes[univIndex]);
@@ -190,6 +195,9 @@ void sACNUniverseListModel::sourceChanged(sACNSource *source)
             ||
             (univIndex < 0)
         ) { return; }
+
+    // Display sources that only transmit 0xdd?
+    if (!m_displayDDOnlySource && !source->doing_dmx) { return; }
 
     // Update existing source
     sACNBasicSourceInfo *info = Q_NULLPTR;

--- a/src/sacn/sacnuniverselistmodel.h
+++ b/src/sacn/sacnuniverselistmodel.h
@@ -76,6 +76,7 @@ private:
     int m_start;
     QTimer *m_checkTimeoutTimer;
     QList<QSharedPointer<sACNListener>> m_listeners;
+    bool m_displayDDOnlySource;
 };
 
 #endif // SACNUNIVERSELISTMODEL_H

--- a/src/universeview.h
+++ b/src/universeview.h
@@ -84,6 +84,7 @@ private:
     QSharedPointer<sACNListener> m_listener;
     MergedUniverseLogger *m_logger;
     QWidget *m_parentWindow;
+    bool m_displayDDOnlySource;
 };
 
 #endif // UNIVERSEVIEW_H

--- a/ui/preferencesdialog.ui
+++ b/ui/preferencesdialog.ui
@@ -36,7 +36,7 @@
    <item alignment="Qt::AlignVCenter">
     <widget class="QGroupBox" name="gbNetworkInterface">
      <property name="title">
-      <string>Network Interface</string>
+      <string>Network Interface*</string>
      </property>
     </widget>
    </item>
@@ -132,6 +132,25 @@
         </property>
         <property name="text">
          <string>Display Blind/Visualizer Data</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cbDisplayDDOnlys">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Display sources with no DMX Data*</string>
         </property>
        </widget>
       </item>
@@ -284,6 +303,22 @@
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblRestartInfo">
+     <property name="font">
+      <font>
+       <pointsize>7</pointsize>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>*Application restart required on change  </string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
It's valid for a source to only send a 0xdd packet for a universe and not 0x00.
Display these appropriately and as required by preferences