### PR TITLE
Revert "Include architecture in AppImage filename by using default naming scheme"

### DIFF
--- a/sACNView.pro
+++ b/sACNView.pro
@@ -176,7 +176,6 @@ macx {
 }
 linux {
     DEB_SANITIZED_VERSION = $$system(echo $$GIT_VERSION | sed 's/[a-zA-Z]//')
-    VERSION = $$system(echo $$GIT_VERSION | sed 's/[a-zA-Z]//')
 
     DEPLOY_DIR = $${_PRO_FILE_PWD_}/install/linux
     DEPLOY_TARGET = $${DEPLOY_DIR}/AppDir/$${TARGET}
@@ -193,7 +192,7 @@ linux {
     PRE_DEPLOY_COMMAND += && $$QMAKE_COPY $${DEPLOY_DIR}/usr/share/applications/sacnview.desktop $${DEPLOY_DIR}/AppDir/sacnview.desktop
     PRE_DEPLOY_COMMAND += && $$QMAKE_COPY $${_PRO_FILE_PWD_}/res/Logo.png $${DEPLOY_DIR}/AppDir/sacnview.png
 
-    DEPLOY_CLEANUP = $$QMAKE_COPY $${OUT_PWD}/$${TARGET}*.AppImage $${DEPLOY_DIR}/
+    DEPLOY_CLEANUP = $$QMAKE_COPY $${OUT_PWD}/$${TARGET}*.AppImage $${DEPLOY_DIR}/$${TARGET}_$${DEB_SANITIZED_VERSION}.AppImage
 
     DEPLOY_INSTALLER = $${QMAKE_DEL_FILE} $${DEPLOY_DIR}/*.deb
     DEPLOY_INSTALLER += && $$QMAKE_COPY $${_PRO_FILE_PWD_}/LICENSE $${DEPLOY_DIR}/COPYRIGHT


### PR DESCRIPTION
Reverts docsteer/sacnview#85 - wasn't fixed enough, breaks linux build still