### PR TITLE
Windows XP Support (Dual Binary)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,64 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# branches to build
+#branches:
+#  # whitelist
+#  only:
+#    - master
+
+# Start builds on tags only
+#skip_non_tags: true
+
+# Build worker image (VM template)
+image: Visual Studio 2015
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+environment:
+  matrix:
+    - QT_Ver: 5.9
+    - QT_Ver: 5.6
+
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform: x86
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration: Release
+
+build:
+  parallel: true                  # enable MSBuild parallel builds
+
+  # MSBuild verbosity level
+  verbosity: detailed
+
+init:
+  - appveyor UpdateBuild -Version %APPVEYOR_REPO_COMMIT%"
+
+install:
+  # MSVC Paths
+  # https://www.appveyor.com/docs/lang/cpp/#visual-studio
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+
+  # QT Paths
+  # https://www.appveyor.com/docs/build-environment/#qt
+  - set QTDIR=C:\Qt\%QT_Ver%\msvc2015
+  - set PATH=%PATH%;%QTDIR%\bin
+
+  # NSIS Paths
+  # https://www.appveyor.com/docs/build-environment/#tools
+  - set PATH=%PATH%;C:\Program Files (x86)\NSIS
+
+  # NSIS Plugin (SimpleFC)
+  - appveyor DownloadFile http://nsis.sourceforge.net/mediawiki/images/d/d7/NSIS_Simple_Firewall_Plugin_1.20.zip
+  - 7z e NSIS_Simple_Firewall_Plugin_1.20.zip -o"C:\Program Files (x86)\NSIS\Plugins\x86-ansi" SimpleFC.dll
+
+build_script:
+  - qmake
+  - nmake
+
+artifacts:
+  - path: install\win\*.exe

--- a/install/win/install.nsi
+++ b/install/win/install.nsi
@@ -128,9 +128,16 @@ Function .onInit
         !insertmacro UNINSTALL.LOG_PREPARE_INSTALL
 		
 		;check the Windows version
-		${IfNot} ${AtLeastWin7}
-		MessageBox MB_OK "Windows 7 or above is required to run sACNView"
-		Quit
+		${If} ${TARGET_WINXP} == '1'
+			${IfNot} ${IsWinXP}
+			MessageBox MB_OK "Windows XP is required to run this special build of sACNView"
+			Quit
+			${EndIf}
+		${Else}
+			${IfNot} ${AtLeastWin7}
+			MessageBox MB_OK "Windows 7 or above is required to run sACNView"
+			Quit
+			${EndIf}
 		${EndIf}
 FunctionEnd
 

--- a/sACNView.pro
+++ b/sACNView.pro
@@ -49,7 +49,16 @@ DEFINES += GIT_DATE_DAY=\\\"$$GIT_DATE_DAY\\\"
 DEFINES += GIT_DATE_DATE=\\\"$$GIT_DATE_DATE\\\"
 DEFINES += GIT_DATE_MONTH=\\\"$$GIT_DATE_MONTH\\\"
 DEFINES += GIT_DATE_YEAR=\\\"$$GIT_DATE_YEAR\\\"
-DEFINES += VERSION=\\\"$$GIT_TAG\\\"
+lessThan(QT_MAJOR_VERSION, 6):lessThan(QT_MINOR_VERSION, 7) {
+    # Windows XP Special Build
+    QMAKE_LFLAGS_WINDOWS = /SUBSYSTEM:WINDOWS,5.01
+    DEFINES += _ATL_XP_TARGETING
+    DEFINES += VERSION=\\\"$$GIT_TAG-WindowsXP\\\"
+    TARGET_WINXP = 1
+} else {
+    DEFINES += VERSION=\\\"$$GIT_TAG\\\"
+    TARGET_WINXP = 0
+}
 
 SOURCES += src/main.cpp\
     src/mdimainwindow.cpp \
@@ -159,12 +168,18 @@ isEmpty(TARGET_EXT) {
 }
 
 win32 {
+    equals(TARGET_WINXP, "1") {
+        PRODUCT_VERSION = "$$GIT_VERSION-WindowsXP"
+    } else {
+        PRODUCT_VERSION = "$$GIT_VERSION"
+    }
+
     DEPLOY_COMMAND = windeployqt
     DEPLOY_DIR = $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/deploy))
     DEPLOY_TARGET = $$shell_quote($$system_path($${OUT_PWD}/release/$${TARGET}$${TARGET_CUSTOM_EXT}))
     DEPLOY_OPT = --dir $${DEPLOY_DIR}
     DEPLOY_CLEANUP = $$QMAKE_COPY $${DEPLOY_TARGET} $${DEPLOY_DIR}
-    DEPLOY_INSTALLER = makensis /DPRODUCT_VERSION="$$GIT_VERSION" $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/win/install.nsi))
+    DEPLOY_INSTALLER = makensis /DPRODUCT_VERSION="$${PRODUCT_VERSION}" /DTARGET_WINXP="$${TARGET_WINXP}" $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/win/install.nsi))
 }
 macx {
     VERSION = $$system(echo $$GIT_VERSION | sed 's/[a-zA-Z]//')

--- a/sACNView.pro
+++ b/sACNView.pro
@@ -35,13 +35,14 @@ TEMPLATE = app
 
 INCLUDEPATH += src src/sacn src/sacn/ACNShare
 
-GIT_VERSION = $$system(git --git-dir $$PWD/.git --work-tree $$PWD describe --always --tags)
-GIT_DATE_DAY = $$system(git --git-dir $$PWD/.git --work-tree $$PWD show -s --date=format:\"%a\" --format=\"%cd\" $$GIT_VERSION)
-GIT_DATE_DATE = $$system(git --git-dir $$PWD/.git --work-tree $$PWD show -s --date=format:\"%d\" --format=\"%cd\" $$GIT_VERSION)
-GIT_DATE_MONTH = $$system(git --git-dir $$PWD/.git --work-tree $$PWD show -s --date=format:\"%b\" --format=\"%cd\" $$GIT_VERSION)
-GIT_DATE_YEAR = $$system(git --git-dir $$PWD/.git --work-tree $$PWD show -s --date=format:\"%Y\" --format=\"%cd\" $$GIT_VERSION)
-GIT_TAG = $$system(git --git-dir $$PWD/.git --work-tree $$PWD describe --abbrev=0 --always --tags)
-GIT_SHA1 = $$system(git --git-dir $$PWD/.git --work-tree $$PWD rev-parse --short HEAD)
+GIT_COMMAND = git --git-dir $$shell_quote($$PWD/.git) --work-tree $$shell_quote($$PWD)
+GIT_VERSION = $$system($$GIT_COMMAND describe --always --tags)
+GIT_DATE_DAY = $$system($$GIT_COMMAND show -s --date=format:\"%a\" --format=\"%cd\" $$GIT_VERSION)
+GIT_DATE_DATE = $$system($$GIT_COMMAND show -s --date=format:\"%d\" --format=\"%cd\" $$GIT_VERSION)
+GIT_DATE_MONTH = $$system($$GIT_COMMAND show -s --date=format:\"%b\" --format=\"%cd\" $$GIT_VERSION)
+GIT_DATE_YEAR = $$system($$GIT_COMMAND show -s --date=format:\"%Y\" --format=\"%cd\" $$GIT_VERSION)
+GIT_TAG = $$system($$GIT_COMMAND describe --abbrev=0 --always --tags)
+GIT_SHA1 = $$system($$GIT_COMMAND rev-parse --short HEAD)
 
 DEFINES += GIT_CURRENT_SHA1=\\\"$$GIT_VERSION\\\"
 DEFINES += GIT_DATE_DAY=\\\"$$GIT_DATE_DAY\\\"
@@ -159,11 +160,11 @@ isEmpty(TARGET_EXT) {
 
 win32 {
     DEPLOY_COMMAND = windeployqt
-    DEPLOY_DIR = $$system_path($${_PRO_FILE_PWD_}/install/deploy)
-    DEPLOY_TARGET = $$system_path($${OUT_PWD}/release/$${TARGET}$${TARGET_CUSTOM_EXT})
+    DEPLOY_DIR = $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/deploy))
+    DEPLOY_TARGET = $$shell_quote($$system_path($${OUT_PWD}/release/$${TARGET}$${TARGET_CUSTOM_EXT}))
     DEPLOY_OPT = --dir $${DEPLOY_DIR}
     DEPLOY_CLEANUP = $$QMAKE_COPY $${DEPLOY_TARGET} $${DEPLOY_DIR}
-    DEPLOY_INSTALLER = makensis /DPRODUCT_VERSION="$$GIT_VERSION" $$system_path($${_PRO_FILE_PWD_}/install/win/install.nsi)
+    DEPLOY_INSTALLER = makensis /DPRODUCT_VERSION="$$GIT_VERSION" $$shell_quote($$system_path($${_PRO_FILE_PWD_}/install/win/install.nsi))
 }
 macx {
     VERSION = $$system(echo $$GIT_VERSION | sed 's/[a-zA-Z]//')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,32 @@ int main(int argc, char *argv[])
     a.setOrganizationName("sACNView");
     a.setOrganizationDomain("tomsteer.net");
 
+    // Windows XP Support
+    #ifdef Q_OS_WIN
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+            #pragma message("This binary is intended for Windows >= 7")
+        #endif
+        #if (QT_VERSION < QT_VERSION_CHECK(5, 7, 0))
+            #pragma message("This binary is intended for Windows XP ONLY")
+            QSysInfo systemInfo;
+            QMessageBox msgBox;
+            msgBox.setStandardButtons(QMessageBox::Ok);
+            if (
+                    (systemInfo.kernelVersion().startsWith(QString("5.1"))) // Windows XP 32bit
+                || (systemInfo.kernelVersion().startsWith(QString("5.2")))) // Windows XP 64bit
+            {
+                msgBox.setIcon(QMessageBox::Information);
+                msgBox.setText(QObject::tr("This binary is intended for Windows XP only\r\nThere are major issues mixed IPv4 and IPv6 enviroments\r\n\r\nPlease ensure IPv6 is disabled"));
+                msgBox.exec();
+            } else {
+                msgBox.setIcon(QMessageBox::Critical);
+                msgBox.setText(QObject::tr("This binary is intended for Windows XP only"));
+                msgBox.exec();
+                a.exit();
+                return -1;
+            }
+        #endif
+    #endif
 
     // Check web (if avaliable) for new version
     VersionCheck version;

--- a/src/sacn/sacnsocket.cpp
+++ b/src/sacn/sacnsocket.cpp
@@ -45,7 +45,11 @@ bool sACNRxSocket::bindMulticast(quint16 universe)
     if (ok)
     {
         #if (QT_VERSION <= QT_VERSION_CHECK(5, 8, 0))
-        #error setMulticastInterface() fails to bind to correct interface on systems running IPV4 and IPv6 with QT <= 5.8.0
+            #ifdef Q_OS_WIN
+                #pragma message("setMulticastInterface() fails to bind to correct interface on systems running IPV4 and IPv6 with QT <= 5.8.0")
+            #else
+                #error setMulticastInterface() fails to bind to correct interface on systems running IPV4 and IPv6 with QT <= 5.8.0
+            #endif
         #endif
         setMulticastInterface(iface);
         ok |= joinMulticastGroup(QHostAddress(addr.GetV4Address()), iface);

--- a/src/versioncheck.cpp
+++ b/src/versioncheck.cpp
@@ -23,7 +23,9 @@ NewVersionDialog::NewVersionDialog(QWidget *parent) : QDialog(parent), ui(new Ui
 {
     ui->setupUi(this);
     ui->stackedWidget->setCurrentIndex(0);
-    setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
+        setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+    #endif
     connect(ui->btnLater, SIGNAL(pressed()), this, SLOT(reject()));
     m_manager = new QNetworkAccessManager(this);
 }


### PR DESCRIPTION
In reference to #63
Creates a Windows XP only binary and installer, with appropriate warnings about IPv6 related bugs.
N.B. IPv6 in Windows XP was an optional extra.

Binaries and installers are created by AppVeyor