### PR TITLE
Revert of "Update Appveyor QT version to 5.10"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ version: '{build}'
 
 environment:
   matrix:
-    - QT_Ver: 5.10.0
+    - QT_Ver: 5.9.4
     - QT_Ver: 5.6
 
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.


### PR DESCRIPTION
QT5.10 (and QT5.9.3) is affected by QTBUG-64784