### PR TITLE
Only show ipv4 address in preferences.

### DIFF
--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -41,7 +41,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
                 ok = true;
                 if(!ipString.isEmpty())
                     ipString.append(",");
-                ipString.append(e.ip().toString());
+                ipString.append(convertIpAddress(e.ip().toIPv4Address()));
             }
         }
 
@@ -97,6 +97,16 @@ PreferencesDialog::~PreferencesDialog()
     delete ui;
 }
 
+// Converts a qipv4address integer to a displayable string.
+QString
+PreferencesDialog::convertIpAddress(quint32 address)
+{
+    return QString("%1.%2.%3.%4")
+            .arg(QString::number(address >> 24 & 0xFF))
+            .arg(QString::number(address >> 16 & 0xFF))
+            .arg(QString::number(address >> 8 & 0xFF))
+            .arg(QString::number(address & 0xFF));
+}
 
 void PreferencesDialog::on_buttonBox_accepted()
 {

--- a/src/preferencesdialog.h
+++ b/src/preferencesdialog.h
@@ -41,6 +41,7 @@ private:
     Ui::PreferencesDialog *ui;
     QList<QNetworkInterface> m_interfaceList;
     QList<QRadioButton*> m_interfaceButtons;
+    QString convertIpAddress(quint32 address);
 
 };
 


### PR DESCRIPTION
Previously the preferences dialog showed both ipv4 and ipv6 address if the interface had both.
This adjusts it to only show the ipv4 address, as sacn/multicast does not care about the ipv6 side.

  QT Doesn't present a user-facing method of only fetching the ipv4 address in string form, so I added a method to convert the int back to a string.  It's likely that this change should end up in nicpicker as well, but I didn't want to duplicate the code until necessary.

This was motivated by one of my interfaces having 8 ipv6 addresses (not sure why... network magic I suppose? Which resulted in a gigantically wide dialog.  I started to look into it, and then realized that the ipv6 information was irrelevant to the display anyways.

