### PR TITLE
E1.31:2016 6.6.2 changes

### DIFF
--- a/sACNView.pro
+++ b/sACNView.pro
@@ -158,7 +158,8 @@ HEADERS += src/mdimainwindow.h \
     src/addmultidialog.h \
     src/ethernetstrut.h \
     src/theme/darkstyle.h \
-    src/xpwarning.h
+    src/xpwarning.h \
+    src/sacn/e1_11.h
 
 FORMS += ui/mdimainwindow.ui \
     ui/scopewindow.ui \

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -232,6 +232,7 @@ void Preferences::savePreferences()
     settings.setValue(S_MAINWINDOWGEOM, m_mainWindowGeometry);
     settings.setValue(S_LISTEN_ALL, m_interfaceListenAll);
     settings.setValue(S_THEME, m_theme);
+    settings.setValue(S_TX_RATE_OVERRIDE, m_txrateoverride);
 
     settings.beginWriteArray(S_SUBWINDOWLIST);
     for(int i=0; i<m_windowInfo.count(); i++)
@@ -271,6 +272,7 @@ void Preferences::loadPreferences()
     m_saveWindowLayout = settings.value(S_SAVEWINDOWLAYOUT, QVariant(false)).toBool();
     m_mainWindowGeometry = settings.value(S_MAINWINDOWGEOM, QVariant(QByteArray())).toByteArray();
     m_theme = (Theme) settings.value(S_THEME, QVariant((int)THEME_LIGHT)).toInt();
+    m_txrateoverride = settings.value(S_TX_RATE_OVERRIDE, QVariant(false)).toBool();
 
     m_windowInfo.clear();
     int size = settings.beginReadArray(S_SUBWINDOWLIST);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -41,6 +41,7 @@ static const QString S_SUBWINDOWNAME("SubWindow Name");
 static const QString S_SUBWINDOWGEOM("SubWindow Geometry");
 static const QString S_LISTEN_ALL("Listen All");
 static const QString S_THEME("Theme");
+static const QString S_TX_RATE_OVERRIDE("TX Rate Override");
 
 struct MDIWindowInfo
 {
@@ -110,6 +111,7 @@ public:
     void SetSavedWindows(QList<MDIWindowInfo> values);
     void SetNetworkListenAll(const bool &value);
     void SetTheme(Theme theme);
+    void SetTXRateOverride(bool override) { m_txrateoverride = override; }
 
     unsigned int GetDisplayFormat();
     unsigned int GetMaxLevel();
@@ -124,6 +126,7 @@ public:
     QList<MDIWindowInfo> GetSavedWindows();
     bool GetNetworkListenAll();
     Theme GetTheme();
+    bool GetTXRateOverride() { return m_txrateoverride; }
 
     QString GetFormattedValue(unsigned int nLevelInDecimal, bool decorated = false);
 
@@ -151,6 +154,7 @@ private:
     QByteArray m_mainWindowGeometry;
     QList<MDIWindowInfo> m_windowInfo;
     Theme m_theme;
+    bool m_txrateoverride;
 
     void loadPreferences();
 

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -86,6 +86,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
         ui->gbTransmitTimeout->setChecked(false);
     }
 
+    ui->cbTxRateOverride->setChecked(Preferences::getInstance()->GetTXRateOverride());
+
     ui->cbTheme->clear();
     ui->cbTheme->addItems(Preferences::ThemeDescriptions);
     ui->cbTheme->setCurrentIndex((int)Preferences::getInstance()->GetTheme());
@@ -124,6 +126,10 @@ void PreferencesDialog::on_buttonBox_accepted()
     p->SetNumSecondsOfSacn(seconds);
 
     p->SetDefaultTransmitName(ui->leDefaultSourceName->text());
+
+    if (ui->cbTxRateOverride->isChecked() != p->GetTXRateOverride())
+        requiresRestart = true;
+    p->SetTXRateOverride(ui->cbTxRateOverride->isChecked());
 
     for(int i=0; i<m_interfaceButtons.count(); i++)
     {

--- a/src/sacn/e1_11.h
+++ b/src/sacn/e1_11.h
@@ -1,0 +1,8 @@
+#ifndef E1_11_H
+#define E1_11_H
+
+namespace E1_11 {
+    static const uint MAX_REFRESH_RATE_HZ = 44; // E1.11:2008 Table 6
+}
+
+#endif // E1_11_H

--- a/src/sacn/sacnlistener.cpp
+++ b/src/sacn/sacnlistener.cpp
@@ -44,8 +44,8 @@ sACNListener::sACNListener(int universe, QObject *parent) : QObject(parent),
     m_isSampling(true),
     m_mergesPerSecond(0)
 {
-    m_merged_levels.reserve(512);
-    for(int i=0; i<512; i++)
+    m_merged_levels.reserve(DMX_SLOT_MAX);
+    for(int i=0; i<DMX_SLOT_MAX; i++)
         m_merged_levels << sACNMergedAddress();
 }
 
@@ -66,7 +66,7 @@ void sACNListener::startReception()
 
     if (Preferences::getInstance()->GetNetworkListenAll()) {
         // Listen on ALL interfaces
-        foreach(QNetworkInterface interface, QNetworkInterface::allInterfaces())
+        for (auto interface : QNetworkInterface::allInterfaces())
         {
             // If the interface is ok for use...
             if(Preferences::getInstance()->interfaceSuitable(&interface))
@@ -168,7 +168,7 @@ void sACNListener::readPendingDatagrams()
     #endif
 
     // Check all sockets
-    foreach (sACNRxSocket* m_socket, m_sockets)
+    for (auto m_socket : m_sockets)
     {
         while(m_socket->hasPendingDatagrams())
         {
@@ -458,12 +458,12 @@ void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHost
             }
             // This is DMX
             // Copy the last array back
-            memcpy(ps->last_level_array, ps->level_array, 512);
+            memcpy(ps->last_level_array, ps->level_array, DMX_SLOT_MAX);
             // Fill in the new array
-            memset(ps->level_array, 0, 512);
+            memset(ps->level_array, 0, DMX_SLOT_MAX);
             memcpy(ps->level_array, pdata, slot_count);
             // Compare the two
-            for(int i=0; i<512; i++)
+            for(int i=0; i<DMX_SLOT_MAX; i++)
             {
                 if(ps->level_array[i]!=ps->last_level_array[i])
                 {
@@ -497,12 +497,12 @@ void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHost
             }
 
             // Copy the last array back
-            memcpy(ps->last_priority_array, ps->priority_array, 512);
+            memcpy(ps->last_priority_array, ps->priority_array, DMX_SLOT_MAX);
             // Fill in the new array
-            memset(ps->priority_array, 0, 512);
+            memset(ps->priority_array, 0, DMX_SLOT_MAX);
             memcpy(ps->priority_array, pdata, slot_count);
             // Compare the two
-            for(int i=0; i<512; i++)
+            for(int i=0; i<DMX_SLOT_MAX; i++)
             {
                 if(ps->priority_array[i]!=ps->last_priority_array[i])
                 {
@@ -528,14 +528,14 @@ void sACNListener::performMerge()
     //array of addresses to merge. to prevent duplicates and because you can have
     //an odd collection of addresses, addresses[n] would be 'n' for the value in question
     // and -1 if not required
-    int addresses_to_merge[512];
+    int addresses_to_merge[DMX_SLOT_MAX];
     int number_of_addresses_to_merge = 0;
 
-    memset(addresses_to_merge, -1, sizeof(int) * 512);
+    memset(addresses_to_merge, -1, sizeof(int) * DMX_SLOT_MAX);
 
     {
         QMutexLocker locker(&m_monitoredChannelsMutex);
-        foreach(int chan, m_monitoredChannels)
+        for(auto chan: m_monitoredChannels)
         {
             QPointF data;
             data.setX(m_elapsedTime.nsecsElapsed()/1000000.0);
@@ -558,8 +558,8 @@ void sACNListener::performMerge()
     // Step one : find any addresses which have changed
     if(m_mergeAll) // Act like all addresses changed
     {
-        number_of_addresses_to_merge = 512;
-        for(int i=0; i<512; i++)
+        number_of_addresses_to_merge = DMX_SLOT_MAX;
+        for(int i=0; i<DMX_SLOT_MAX; i++)
         {
             addresses_to_merge[i] = i;
         }
@@ -575,7 +575,7 @@ void sACNListener::performMerge()
                 continue; // Inactive source, ignore it
             if(!ps->source_levels_change)
                 continue; // We don't need to consider this one, no change
-            for(int i=0; i<512; i++)
+            for(int i=0; i<DMX_SLOT_MAX; i++)
             {
                 if(ps->dirty_array[i])
                 {
@@ -584,7 +584,7 @@ void sACNListener::performMerge()
                 }
             }
             // Clear the flags
-            memset(ps->dirty_array, 0 , 512);
+            memset(ps->dirty_array, 0 , DMX_SLOT_MAX);
             ps->source_levels_change = false;
         }
     }
@@ -594,8 +594,9 @@ void sACNListener::performMerge()
     // Clear out the sources list for all the affected channels, we'll be refreshing it
 
     int skipCounter = 0;
-    for(int i=0; i < 512 && i<(number_of_addresses_to_merge + skipCounter); i++)
+    for(int i=0; i < DMX_SLOT_MAX && i<(number_of_addresses_to_merge + skipCounter); i++)
     {
+        QMutexLocker mergeLocker(&m_merged_levelsMutex);
         m_merged_levels[i].changedSinceLastMerge = false;
         if(addresses_to_merge[i] == -1) {
             ++skipCounter;
@@ -607,10 +608,10 @@ void sACNListener::performMerge()
 
     // Find the highest priority source for each address we need to work on
 
-    int levels[512];
+    int levels[DMX_SLOT_MAX];
     memset(&levels, -1, sizeof(levels));
 
-    int priorities[512];
+    int priorities[DMX_SLOT_MAX];
     memset(&priorities, -1, sizeof(priorities));
 
     QMultiMap<int, sACNSource*> addressToSourceMap;
@@ -627,13 +628,13 @@ void sACNListener::performMerge()
         }
 
         skipCounter = 0;
-        for(int i=0; i < 512 && i<(number_of_addresses_to_merge + skipCounter); i++)
+        for(int i=0; i < DMX_SLOT_MAX && i<(number_of_addresses_to_merge + skipCounter); i++)
         {
+            QMutexLocker mergeLocker(&m_merged_levelsMutex);
             if(addresses_to_merge[i] == -1) {
                ++skipCounter;
                 continue;
             }
-            sACNMergedAddress *pAddr = &m_merged_levels[addresses_to_merge[i]];
             int address = addresses_to_merge[i];
 
 			if (
@@ -652,7 +653,7 @@ void sACNListener::performMerge()
 			}
 
             if(ps->src_valid && !ps->active.Expired())
-                pAddr->otherSources << ps;
+                m_merged_levels[addresses_to_merge[i]].otherSources.insert(ps);
         }
     }
 
@@ -660,8 +661,9 @@ void sACNListener::performMerge()
 
     // Next, find highest level for the highest prioritized sources
     skipCounter = 0;
-    for(int i=0; i < 512 && i<(number_of_addresses_to_merge + skipCounter); i++)
+    for(int i=0; i < DMX_SLOT_MAX && i<(number_of_addresses_to_merge + skipCounter); i++)
     {
+        QMutexLocker mergeLocker(&m_merged_levelsMutex);
         if(addresses_to_merge[i] == -1) {
             ++skipCounter;
             continue;
@@ -675,7 +677,7 @@ void sACNListener::performMerge()
             m_merged_levels[address].winningSource = NULL;
             m_merged_levels[address].otherSources.clear();
         }
-        foreach(sACNSource *s, sourceList)
+        for (auto s : sourceList)
         {
             if(s->level_array[address] > levels[address])
             {

--- a/src/sacn/sacnlistener.h
+++ b/src/sacn/sacnlistener.h
@@ -65,7 +65,10 @@ public:
      * @return an sACNMergerdSourceList, a list of merged address structures, allowing you to see
      * the result of the merge algorithm together with all the sub-sources, by address
      */
-    sACNMergedSourceList mergedLevels() { return m_merged_levels;}
+    sACNMergedSourceList mergedLevels() {
+        QMutexLocker mergeLocker(&m_merged_levelsMutex);
+        return m_merged_levels;
+    }
 
     int sourceCount() { return m_sources.size();}
     sACNSource *source(int index) { return m_sources[index];}
@@ -132,6 +135,7 @@ private:
     std::vector<sACNSource *> m_sources;
     int m_last_levels[MAX_DMX_ADDRESS];
     sACNMergedSourceList m_merged_levels;
+    QMutex m_merged_levelsMutex;
     int m_universe;
     // The per-source hold last look time
     int m_ssHLL;

--- a/src/sacn/sacnsender.cpp
+++ b/src/sacn/sacnsender.cpp
@@ -64,7 +64,7 @@ void sACNSentUniverse::startSending(bool preview)
         options += PREVIEW_DATA_OPTION;
 
     uint max_tx_rate =
-            Preferences::getInstance()->GetTXRateOverride() ? std::numeric_limits<typeof(max_tx_rate)>::max() : E1_11::MAX_REFRESH_RATE_HZ;
+            Preferences::getInstance()->GetTXRateOverride() ? std::numeric_limits<decltype(max_tx_rate)>::max() : E1_11::MAX_REFRESH_RATE_HZ;
 
     if(m_unicastAddress.isNull())
         streamServer->CreateUniverse(m_cid, qPrintable(m_name), m_priority, 0, options, STARTCODE_DMX,
@@ -360,7 +360,7 @@ void CStreamServer::TickLoop()
                     it->suppresed = false;
                 }
 
-                for (typeof(sendCount) n = 0; n < sendCount; n++ )
+                for (decltype(sendCount) n = 0; n < sendCount; n++ )
                 {
                     //Add the sequence number and send
                     quint8 *pseq = GetPSeq(it->cid, it->number);
@@ -448,7 +448,7 @@ bool CStreamServer::CreateUniverse(const CID& source_cid, const char* source_nam
     m_multiverse[handle].isdirty = false;
     m_multiverse[handle].num_terminates=0;
     m_multiverse[handle].send_interval.SetInterval(send_intervalms);
-    m_multiverse[handle].min_interval.SetInterval(1000 / (std::max(send_max_rate, (typeof(send_max_rate))1)));
+    m_multiverse[handle].min_interval.SetInterval(1000 / (std::max(send_max_rate, (decltype(send_max_rate))1)));
     m_multiverse[handle].draft = draft;
     m_multiverse[handle].cid = source_cid;
 

--- a/src/sacn/sacnsender.cpp
+++ b/src/sacn/sacnsender.cpp
@@ -26,6 +26,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QDebug>
+#include <QCoreApplication>
 
 #include "preferences.h"
 
@@ -62,19 +63,22 @@ void sACNSentUniverse::startSending(bool preview)
     if (preview)
         options += PREVIEW_DATA_OPTION;
 
+    uint max_tx_rate =
+            Preferences::getInstance()->GetTXRateOverride() ? std::numeric_limits<typeof(max_tx_rate)>::max() : E1_11::MAX_REFRESH_RATE_HZ;
+
     if(m_unicastAddress.isNull())
-        streamServer->CreateUniverse(m_cid, qPrintable(m_name), m_priority, 0, options, 0,
-           m_universe, 512, m_slotData, m_handle, false, 850, CIPAddr(), m_version==StreamingACNProtocolVersion::sACNProtocolDraft );
+        streamServer->CreateUniverse(m_cid, qPrintable(m_name), m_priority, 0, options, STARTCODE_DMX,
+           m_universe, DMX_SLOT_MAX, m_slotData, m_handle, SEND_INTERVAL_DMX, max_tx_rate, CIPAddr(), m_version==StreamingACNProtocolVersion::sACNProtocolDraft );
     else
-        streamServer->CreateUniverse(m_cid, qPrintable(m_name), m_priority, 0, options, 0, m_universe,
-             512, m_slotData, m_handle, false, 850, CIPAddr(m_unicastAddress), m_version==StreamingACNProtocolVersion::sACNProtocolDraft );
+        streamServer->CreateUniverse(m_cid, qPrintable(m_name), m_priority, 0, options, STARTCODE_DMX, m_universe,
+             DMX_SLOT_MAX, m_slotData, m_handle, SEND_INTERVAL_DMX, max_tx_rate, CIPAddr(m_unicastAddress), m_version==StreamingACNProtocolVersion::sACNProtocolDraft );
 
     streamServer->SetUniverseDirty(m_handle);
 
     if(m_priorityMode == pmPER_ADDRESS_PRIORITY)
     {
         quint8 *pslots;
-        streamServer->CreateUniverse(m_cid, qPrintable(m_name), 0, options, 0, 0xDD, m_universe, 512, pslots, m_priorityHandle);
+        streamServer->CreateUniverse(m_cid, qPrintable(m_name), 0, options, 0, STARTCODE_PRIORITY, m_universe, DMX_SLOT_MAX, pslots, m_priorityHandle, SEND_INTERVAL_PRIORITY, max_tx_rate);
         memcpy(pslots, m_perChannelPriorities, sizeof(m_perChannelPriorities));
         streamServer->SetUniverseDirty(m_priorityHandle);
     }
@@ -107,7 +111,7 @@ void sACNSentUniverse::stopSending()
 
 void sACNSentUniverse::setLevel(quint16 address, quint8 value)
 {
-    Q_ASSERT(address<512);
+    Q_ASSERT(address<DMX_SLOT_MAX);
     if(isSending())
     {
         m_slotData[address] =  value;
@@ -117,8 +121,8 @@ void sACNSentUniverse::setLevel(quint16 address, quint8 value)
 
 void sACNSentUniverse::setLevelRange(quint16 start, quint16 end, quint8 value)
 {
-    Q_ASSERT(start<512);
-    Q_ASSERT(end<512);
+    Q_ASSERT(start<DMX_SLOT_MAX);
+    Q_ASSERT(end<DMX_SLOT_MAX);
     Q_ASSERT(start<=end);
     if(isSending())
     {
@@ -142,7 +146,7 @@ void sACNSentUniverse::setVerticalBar(quint16 index, quint8 level)
 
     if(isSending())
     {
-        memset(m_slotData, 0, 512);
+        memset(m_slotData, 0, DMX_SLOT_MAX);
         for(int i=0; i<16; i++)
         {
             m_slotData[(i*32)+index] = level;
@@ -159,7 +163,7 @@ void sACNSentUniverse::setHorizontalBar(quint16 index, quint8 level)
 
     if(isSending())
     {
-        memset(m_slotData, 0, 512);
+        memset(m_slotData, 0, DMX_SLOT_MAX);
         memset(m_slotData + 32*index, level, 32);
 
         CStreamServer::getInstance()->SetUniverseDirty(m_handle);
@@ -241,18 +245,16 @@ void CStreamServer::shutdown()
     m_instance = Q_NULLPTR;
 }
 
-CStreamServer::CStreamServer()
+CStreamServer::CStreamServer() :
+    m_thread_stop(false)
 {
     m_sendsock = new sACNTxSocket(Preferences::getInstance()->networkInterface());
 
     m_sendsock->bindMulticast();
 
     m_thread = new QThread();
-    connect(m_thread, &QThread::finished, this, &QObject::deleteLater);
-    m_tickTimer = new QTimer(this);
-    m_tickTimer->setInterval(10);
-    connect(m_tickTimer, SIGNAL(timeout()), this, SLOT(Tick()), Qt::DirectConnection);
-    m_tickTimer->start();
+    connect(m_thread, SIGNAL(started()), this, SLOT(TickLoop()));
+    connect(m_thread, &QThread::finished, this, &QThread::deleteLater);
     this->moveToThread(m_thread);
     m_thread->start();
 }
@@ -268,7 +270,10 @@ CStreamServer::~CStreamServer()
             it3->second.second = Q_NULLPTR;
         }
     }
+
+    m_thread_stop = true;
     m_thread->quit();
+    m_thread->wait();
 }
 
 
@@ -313,57 +318,76 @@ void CStreamServer::RemovePSeq(const CID &cid, quint16 universe)
 }
 
 
-void CStreamServer::Tick()
+void CStreamServer::TickLoop()
 {
-    QMutexLocker locker(&m_writeMutex);
+    qDebug() << "sACNSender" << QThread::currentThreadId() << ": Starting";
 
-    int valid_count = 0;
-    for(verseiter it = m_multiverse.begin(); it != m_multiverse.end(); ++it)
-    {
-        if(it->psend)
-            ++valid_count;
+    while (!m_thread_stop) {
+        QThread::yieldCurrentThread();
+        QThread::msleep(1);
+        QMutexLocker locker(&m_writeMutex);
 
-        //If this has been send 3 times (or more?) with a termination flag
-        //then it's time to kill it
-        if(it->num_terminates >= 3)
+        int valid_count = 0;
+        for(auto it = m_multiverse.begin(); it != m_multiverse.end(); ++it)
         {
-            DoDestruction(it->handle);
-        }
+            if(it->psend)
+                ++valid_count;
 
-        //If valid, either a dirty, inactivity count < 3 (if we're using that logic), or send_interval will cause a send
-        if(it->psend && (it->isdirty ||
-                             (it->waited_for_dirty &&
-                                ((!it->ignore_inactivity && it->inactive_count < 3) ||
-                                 it->send_interval.Expired()))))
-        {
-            //Before the send, properly reset state
-            if(it->isdirty)
-                it->inactive_count = 0;  //To recover from inactivity
-            else if(it->inactive_count < 3)  //We don't want the Expired case to reset the inactivity count
-                ++it->inactive_count;
+            //Too soon to send?
+            //E1.31:2016 6.6.1
+            if (!it->min_interval.Expired())
+                continue;
 
-            //Add the sequence number and send
-            quint8 *pseq = GetPSeq(it->cid, it->number);
-            SetStreamHeaderSequence(it->psend, *pseq, it->draft);
-            (*pseq)++;
-
-            quint64 result = m_sendsock->writeDatagram( (char*)it->psend, it->sendsize, it->sendaddr, STREAM_IP_PORT);
-            if(result!=it->sendsize)
+            //If this has been send 3 times (or more?) with a termination flag
+            //then it's time to kill it
+            if(it->num_terminates >= 3)
             {
-                qDebug() << "Error sending datagram : " << m_sendsock->errorString();
+                DoDestruction(it->handle);
             }
 
-            if(GetStreamTerminated(it->psend))
+            //If valid, either a dirty, or send_interval will cause a send
+            if(it->psend && (it->isdirty || it->send_interval.Expired()))
             {
-                it->num_terminates++;
+                // E1.31:2016 6.6.2 (clause 1) logic
+                quint8 sendCount = 1;
+                if(!it->isdirty && it->send_interval.Expired() && !it->suppresed && it->start_code == STARTCODE_DMX)
+                {
+                    it->suppresed = true;
+                    sendCount = 3;
+                }
+                else if (it->isdirty)
+                {
+                    it->suppresed = false;
+                }
+
+                for (typeof(sendCount) n = 0; n < sendCount; n++ )
+                {
+                    //Add the sequence number and send
+                    quint8 *pseq = GetPSeq(it->cid, it->number);
+                    SetStreamHeaderSequence(it->psend, *pseq, it->draft);
+                    (*pseq)++;
+
+                    quint64 result = m_sendsock->writeDatagram( (char*)it->psend, it->sendsize, it->sendaddr, STREAM_IP_PORT);
+                    if(result!=it->sendsize)
+                    {
+                        qDebug() << "Error sending datagram : " << m_sendsock->errorString();
+                    }
+                }
+
+                if(GetStreamTerminated(it->psend))
+                {
+                    it->num_terminates++;
+                }
+
+                //Finally, set the timing/dirtiness for the next interval
+                it->isdirty = false;
+                it->send_interval.Reset();
+                it->min_interval.Reset();
             }
-
-            //Finally, set the timing/dirtiness for the next interval
-            it->isdirty = false;
-            it->send_interval.Reset();
         }
-    }
+    } // Loop
 
+    qDebug() << "sACNSender" << QThread::currentThreadId() << ": Stopping";
 }
 
 
@@ -379,8 +403,7 @@ void CStreamServer::Tick()
 //  inactivity logic, send_intervalms expiry will trigger a resend of the current universe packet.
 //Data on this universe will not be initially sent until marked dirty.
 bool CStreamServer::CreateUniverse(const CID& source_cid, const char* source_name, quint8 priority, quint16 reserved, quint8 options, quint8 start_code,
-                                     quint16 universe, quint16 slot_count, quint8*& pslots, uint& handle,
-                                        bool ignore_inactivity_logic, uint send_intervalms, CIPAddr unicastAddress, bool draft)
+                                     quint16 universe, quint16 slot_count, quint8*& pslots, uint& handle, uint send_intervalms, uint send_max_rate, CIPAddr unicastAddress, bool draft)
 {
     QMutexLocker locker(&m_writeMutex);
     if(universe == 0)
@@ -423,11 +446,9 @@ bool CStreamServer::CreateUniverse(const CID& source_cid, const char* source_nam
     m_multiverse[handle].handle = handle;
     m_multiverse[handle].start_code = start_code;
     m_multiverse[handle].isdirty = false;
-    m_multiverse[handle].waited_for_dirty = false;
     m_multiverse[handle].num_terminates=0;
-    m_multiverse[handle].ignore_inactivity = ignore_inactivity_logic;
-    m_multiverse[handle].inactive_count = 0;
     m_multiverse[handle].send_interval.SetInterval(send_intervalms);
+    m_multiverse[handle].min_interval.SetInterval(1000 / (std::max(send_max_rate, (typeof(send_max_rate))1)));
     m_multiverse[handle].draft = draft;
     m_multiverse[handle].cid = source_cid;
 
@@ -462,7 +483,6 @@ void CStreamServer::SetUniverseDirty(uint handle)
 {
     QMutexLocker locker(&m_writeMutex);
     m_multiverse[handle].isdirty = true;
-    m_multiverse[handle].waited_for_dirty = true;
 }
 
 //In the event that you want to send out a message for a particular

--- a/src/sacn/streamcommon.h
+++ b/src/sacn/streamcommon.h
@@ -94,6 +94,7 @@
 #define RLP_PREAMBLE_SIZE 16
 #define RLP_POSTAMBLE_SIZE 0
 #define ACN_IDENTIFIER_SIZE 12
+#define DMX_SLOT_MAX 512
 
 //for support of the early draft
 #define DRAFT_STREAM_HEADER_SIZE 90

--- a/src/sacn/streamingacn.cpp
+++ b/src/sacn/streamingacn.cpp
@@ -134,7 +134,7 @@ QSharedPointer<sACNListener> sACNManager::getListener(int universe)
     {
         #ifdef QT_GUI_LIB
             QMessageBox msgBox;
-            msgBox.setText("Unable to allocate listener object\r\n\r\nsACNView must close now");
+            msgBox.setText(tr("Unable to allocate listener object\r\n\r\nsACNView must close now"));
             msgBox.exec();
         #else
             qDebug() << "Unable to allocate listener object\r\n\r\nsACNView must close now";

--- a/ui/preferencesdialog.ui
+++ b/ui/preferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>420</width>
-    <height>600</height>
+    <width>476</width>
+    <height>647</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -217,6 +217,19 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cbTxRateOverride">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Allow rates to exceed E1.11 (E1.31:2016 6.6.1)*</string>
+        </property>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
Limit default packet rate to 44pkt/s (Resolves #130)
-Allow user to override packet rate
Reimplemented multiple packets before transmission suppression.
Replaced FOREACH macro with C++11 ranged for in listener