### PR TITLE
Added snapshot replay button

### DIFF
--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -83,6 +83,10 @@ void Snapshot::setState(state s)
     {
     case stSetup:
         stopSnapshot();
+        if(m_snapshotData.isEmpty())
+            ui->btnReplay->hide();
+        else
+            ui->btnReplay->show();
         ui->btnPlay->setEnabled(false);
         ui->btnSnapshot->setEnabled(ui->tableWidget->rowCount()>0);
         ui->lbTimer->setText("");
@@ -106,6 +110,7 @@ void Snapshot::setState(state s)
     case stCountDown3:
     case stCountDown2:
     case stCountDown1:
+        ui->btnReplay->hide();
         ui->btnAddRow->setEnabled(false);
         ui->btnRemoveRow->setEnabled(false);
         ui->btnSnapshot->setEnabled(false);
@@ -122,6 +127,7 @@ void Snapshot::setState(state s)
             t->setVisible(false);
         break;
     case stReadyPlayback:
+        ui->btnReplay->hide();
         ui->btnPlay->setEnabled(true);
         ui->btnSnapshot->setEnabled(true);
         ui->lbTimer->setText("");
@@ -139,7 +145,9 @@ void Snapshot::setState(state s)
         foreach(QToolButton *t, m_enableButtons)
             t->setVisible(false);
         break;
+    case stReplay:
     case stPlayback:
+        ui->btnReplay->hide();
         ui->btnPlay->setEnabled(true);
         ui->btnSnapshot->setEnabled(false);
         ui->lbTimer->setText("");
@@ -192,10 +200,15 @@ void Snapshot::on_btnSnapshot_pressed()
 
 void Snapshot::on_btnPlay_pressed()
 {
-    if(m_state!=stPlayback)
+    if(m_state!=stPlayback && m_state!= stReplay)
         setState(stPlayback);
     else
         setState(stSetup);
+}
+
+void Snapshot::on_btnReplay_pressed()
+{
+    setState(stReplay);
 }
 
 void Snapshot::saveSnapshot()

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -25,7 +25,8 @@ class Snapshot : public QWidget
         stCountDown2,
         stCountDown1,
         stReadyPlayback,
-        stPlayback
+        stPlayback,
+        stReplay
     };
 
 public:
@@ -35,6 +36,7 @@ protected slots:
     void counterTick();
     void on_btnSnapshot_pressed();
     void on_btnPlay_pressed();
+    void on_btnReplay_pressed();
     void on_btnAddRow_pressed();
     void on_btnRemoveRow_pressed();
     void senderTimedOut();

--- a/ui/snapshot.ui
+++ b/ui/snapshot.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>330</width>
-    <height>358</height>
+    <height>404</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -155,6 +155,32 @@
      </property>
      <property name="text">
       <string>Play Back Snapshot</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../res/resources.qrc">
+       <normaloff>:/icons/play.png</normaloff>:/icons/play.png</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextUnderIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="btnReplay">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Replay Last Snapshot</string>
      </property>
      <property name="icon">
       <iconset resource="../res/resources.qrc">


### PR DESCRIPTION
There are times in sACNView when one accidentally stops a running snapshot, and there's no easy way to restore the previous look. Added a "replay" button (which could use a better icon) that appears if someone stops a snapshot but hasn't yet recorded a new one. 
Note - because of new 2.1 branch dependencies, I can't build the project at the moment. I did originally test this change against the master branch, so I have reasonable confidence that the fix is fine. :) 