### PR TITLE
Socket cleanup

### DIFF
--- a/libs.pri
+++ b/libs.pri
@@ -106,6 +106,9 @@ win32 {
     equals(QT_MAJOR_VERSION, 5):equals(QT_MINOR_VERSION, 10) { #https://wiki.qt.io/Qt_5.10_Tools_and_Versions
         OPENSSL_VERS = 1.0.2j
     }
+    equals(QT_MAJOR_VERSION, 5):equals(QT_MINOR_VERSION, 11) { #https://wiki.qt.io/Qt_5.11_Tools_and_Versions
+        OPENSSL_VERS = 1.0.2j
+    }
     contains(QT_ARCH, i386) {
         OPENSSL_PATH = $${_PRO_FILE_PWD_}/libs/openssl-$${OPENSSL_VERS}-i386-win32
     } else {

--- a/src/nicselectdialog.cpp
+++ b/src/nicselectdialog.cpp
@@ -30,7 +30,9 @@ NICSelectDialog::NICSelectDialog(QWidget *parent) :
     {
         // We want interfaces which are up, IPv4, and can multicast
         if(Preferences::getInstance()->interfaceSuitable(&interface)) {
-
+            // But ignore loopback, leave that to work offline
+            if (interface.flags().testFlag(QNetworkInterface::IsLoopBack))
+                break;
             QString ipString;
             foreach (QNetworkAddressEntry e, interface.addressEntries()) {
                 if(e.ip().protocol() == QAbstractSocket::IPv4Protocol) {

--- a/src/pcapplayback.cpp
+++ b/src/pcapplayback.cpp
@@ -43,12 +43,16 @@ void PcapPlayback::openThread()
 
 void PcapPlayback::closeThread()
 {
-    if (sender) sender->quit();
+    if (!sender)
+        return;
+
+    sender->quit();
+    sender->deleteLater();
+    sender = Q_NULLPTR;
 }
 
 void PcapPlayback::playbackThreadClosed()
 {
-    sender = Q_NULLPTR;
     updateUIBtns();
 }
 

--- a/src/pcapplaybacksender.cpp
+++ b/src/pcapplaybacksender.cpp
@@ -17,8 +17,6 @@
 #include "sacn/sacnlistener.h"
 #include "ethernetstrut.h"
 
-
-
 pcapplaybacksender::pcapplaybacksender(QString FileName) :
     m_filename(FileName),
     m_pcap_in(Q_NULLPTR),
@@ -132,9 +130,6 @@ void pcapplaybacksender::run()
             const u_char *pkt_data;
             if (pcap_next_ex(m_pcap_in, &pkt_header, &pkt_data) == 1)
             {
-                // Create QT datagram to send to self
-                QNetworkDatagram pkt_datagram = createDatagram(m_pcap_in, pkt_header, pkt_data);
-
                 // Wait until time
                 if (!m_pktLastTime.isNull())
                 {
@@ -159,22 +154,6 @@ void pcapplaybacksender::run()
                     m_running = false;
                     emit sendingFinished();
                     return;
-                }
-                /* Send to me
-                 *
-                 * Send to any local listener, but set the always pass flag
-                 *
-                 */
-                {
-                    decltype(sACNManager::getInstance()->getListenerList()) listenerList
-                            = sACNManager::getInstance()->getListenerList();
-                    sACNManager::tListener listener = listenerList.begin().value().toStrongRef();
-                    if (listener)
-                        listener->processDatagram(
-                            pkt_datagram.data(),
-                            pkt_datagram.destinationAddress(),
-                            pkt_datagram.senderAddress(),
-                            true);
                 }
 
                 // Save time

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -53,6 +53,14 @@ Preferences *Preferences::getInstance()
 
 QNetworkInterface Preferences::networkInterface() const
 {
+    if (!m_interface.isValid())
+    {
+        for (QNetworkInterface interface : QNetworkInterface::allInterfaces())
+        {
+            if (interface.flags().testFlag(QNetworkInterface::IsLoopBack))
+                return interface;
+        }
+    }
     return m_interface;
 }
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -80,7 +80,11 @@ void Preferences::SetNetworkListenAll(const bool &value)
 
 bool Preferences::GetNetworkListenAll()
 {
+#ifdef TARGET_WINXP
+    return false;
+#else
     return m_interfaceListenAll;
+#endif
 }
 
 QColor Preferences::colorForCID(const CID &cid)

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -59,6 +59,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
         }
     }
     ui->cbListenAll->setChecked(Preferences::getInstance()->GetNetworkListenAll());
+#ifdef TARGET_WINXP
+    ui->cbListenAll->setEnabled(false);
+#endif
 
     switch (Preferences::getInstance()->GetDisplayFormat())
     {

--- a/src/sacn/fpscounter.cpp
+++ b/src/sacn/fpscounter.cpp
@@ -1,19 +1,16 @@
 #include "fpscounter.h"
 #include <QDateTime>
 
+#define updateInterval 1000
+
 fpsCounter::fpsCounter(QObject *parent) : QObject(parent),
-    updateTimer(new QTimer(this)),
     currentFps(0),
     previousFps(0),
     lastTime(0)
 {
-    connect(updateTimer, SIGNAL(timeout()), this, SLOT(updateFPS()));
-    updateTimer->start(1000);
-}
-
-fpsCounter::~fpsCounter()
-{
-    updateTimer->deleteLater();
+    QTimer *timer = new QTimer(this);
+    connect(timer, SIGNAL(timeout()), this, SLOT(updateFPS()));
+    timer->start(updateInterval);
 }
 
 void fpsCounter::updateFPS()
@@ -26,7 +23,7 @@ void fpsCounter::updateFPS()
         // No frames, or very old single frame
         if (
                 (frameTimes.count() == 0) ||
-                ((frameTimes.count() == 1) && (QDateTime::currentMSecsSinceEpoch() > (frameTimes.back() + (updateTimer->interval() * 2))))
+                ((frameTimes.count() == 1) && (QDateTime::currentMSecsSinceEpoch() > (frameTimes.back() + (updateInterval * 2))))
             )
         {
             previousFps = currentFps;

--- a/src/sacn/fpscounter.h
+++ b/src/sacn/fpscounter.h
@@ -11,7 +11,6 @@ class fpsCounter : public QObject
     Q_OBJECT
 public:
     explicit fpsCounter(QObject *parent = nullptr);
-    virtual ~fpsCounter();
 
     // Return current FPS
     float FPS() { newFps = false; return currentFps;}
@@ -27,8 +26,6 @@ private slots:
 
 private:
     typedef time_t quint64;
-
-    QTimer *updateTimer;
 
     float currentFps;
     float previousFps;

--- a/src/sacn/sacndiscovery.cpp
+++ b/src/sacn/sacndiscovery.cpp
@@ -30,7 +30,7 @@ sACNDiscoveryTX::sACNDiscoveryTX() : QObject(),
 {
     // Socket
     m_sendSock = new sACNTxSocket(Preferences::getInstance()->networkInterface(), this);
-    m_sendSock->bindMulticast();
+    m_sendSock->bind();
 
     // Setup packet send timer
     m_sendTimer->setObjectName("sACNDiscoveryTX");

--- a/src/sacn/sacndiscovery.cpp
+++ b/src/sacn/sacndiscovery.cpp
@@ -160,6 +160,7 @@ sACNDiscoveryRX *sACNDiscoveryRX::getInstance()
 }
 
 sACNDiscoveryRX::sACNDiscoveryRX() : QObject(),
+    m_mutex(new QMutex()),
     m_listener(new sACNListener(E131_DISCOVERY_UNIVERSE)),
     m_thread(new QThread(this)),
     m_expiredTimer(new QTimer(this))
@@ -229,6 +230,8 @@ void sACNDiscoveryRX::processPacket(quint8* pbuf, uint buflen)
     CID cid;
     quint8 pageCount;
     quint8 pageNum;
+
+    QMutexLocker locker(m_mutex);
 
     // Check length
     if (!(buflen > E131_UNIVERSE_DISCOVERY_SIZE_MIN) ||

--- a/src/sacn/sacndiscovery.h
+++ b/src/sacn/sacndiscovery.h
@@ -86,6 +86,8 @@ private slots:
 private:
     static sACNDiscoveryRX *m_instance;
 
+    QMutex *m_mutex;
+
     sACNListener *m_listener;
     QThread *m_thread;
 

--- a/src/sacn/sacneffectengine.cpp
+++ b/src/sacn/sacneffectengine.cpp
@@ -52,6 +52,7 @@ sACNEffectEngine::sACNEffectEngine(sACNManager::tSender sender) : QObject(NULL),
     m_thread = new QThread();
     moveToThread(m_thread);
     connect(m_thread, &QThread::finished, this, &QObject::deleteLater);
+    m_thread->setObjectName(QString("Effect Engine Universe %1").arg(sender->universe()));
     m_thread->start();
 
     connect(m_sender, SIGNAL(slotCountChange()), this, SLOT(slotCountChanged()));

--- a/src/sacn/sacnlistener.cpp
+++ b/src/sacn/sacnlistener.cpp
@@ -175,7 +175,7 @@ void sACNListener::readPendingDatagrams()
     }
 }
 
-void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender, bool alwaysPass)
+void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender)
 {
     // Process packet
     CID source_cid;
@@ -219,7 +219,7 @@ void sACNListener::processDatagram(QByteArray data, QHostAddress receiver, QHost
     if(m_universe != universe)
     {
         // Was it unicast? Send to correct listner (if listening)
-        if (!alwaysPass && receiver.isMulticast())
+        if (receiver.isMulticast())
         {
             // Log and discard
             qDebug() << "sACNListener" << QThread::currentThreadId() << ": Wrong Universe and is multicast";

--- a/src/sacn/sacnlistener.cpp
+++ b/src/sacn/sacnlistener.cpp
@@ -101,26 +101,14 @@ void sACNListener::startReception()
 
 void sACNListener::startInterface(QNetworkInterface iface)
 {
-    // Listen multicast
     m_sockets.push_back(new sACNRxSocket(iface));
-    if (m_sockets.back()->bindMulticast(m_universe)) {
+    if (m_sockets.back()->bind(m_universe)) {
         connect(m_sockets.back(), SIGNAL(readyRead()), this, SLOT(readPendingDatagrams()), Qt::DirectConnection);
         m_bindStatus.multicast = eBindStatus::BIND_OK;
     } else {
        // Failed to bind,
        m_sockets.pop_back();
        m_bindStatus.multicast = eBindStatus::BIND_FAILED;
-    }
-
-    // Listen unicast
-    m_sockets.push_back(new sACNRxSocket(iface));
-    if (m_sockets.back()->bindUnicast()) {
-        connect(m_sockets.back(), SIGNAL(readyRead()), this, SLOT(readPendingDatagrams()), Qt::DirectConnection);
-        m_bindStatus.unicast = eBindStatus::BIND_OK;
-    } else {
-       // Failed to bind
-       m_sockets.pop_back();
-       m_bindStatus.unicast = eBindStatus::BIND_FAILED;
     }
 }
 

--- a/src/sacn/sacnlistener.h
+++ b/src/sacn/sacnlistener.h
@@ -79,7 +79,7 @@ public:
      * This allows other listeners to pass on unicast datagrams for other universes
      *
      */
-    Q_INVOKABLE void processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender);
+    Q_INVOKABLE void processDatagram(QByteArray data, QHostAddress destination, QHostAddress sender);
 
     // Diagnostic - the number of merge operations per second
 

--- a/src/sacn/sacnlistener.h
+++ b/src/sacn/sacnlistener.h
@@ -77,10 +77,8 @@ public:
      *  @brief processDatagram Process a suspected sACN datagram.
      * This allows other listeners to pass on unicast datagrams for other universes
      *
-     * if alwaysPass is set, then the function will pass on multicast packets to the correct listener, if required.
-     * Unicast packets are always forwared,as we can not ensure which listener these arrive at.
      */
-    void processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender, bool alwaysPass = false);
+    void processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender);
 
     // Diagnostic - the number of merge operations per second
 

--- a/src/sacn/sacnlistener.h
+++ b/src/sacn/sacnlistener.h
@@ -27,6 +27,7 @@
 #include "streamingacn.h"
 #include "sacnsocket.h"
 
+Q_DECLARE_METATYPE(QHostAddress)
 
 struct sACNMergedAddress
 {
@@ -78,7 +79,7 @@ public:
      * This allows other listeners to pass on unicast datagrams for other universes
      *
      */
-    void processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender);
+    Q_INVOKABLE void processDatagram(QByteArray data, QHostAddress receiver, QHostAddress sender);
 
     // Diagnostic - the number of merge operations per second
 
@@ -129,6 +130,7 @@ private slots:
     void checkSourceExpiration();
     void sampleExpiration();
 private:
+    QMutex m_processMutex;
     void startInterface(QNetworkInterface iface);
     std::list<sACNRxSocket *> m_sockets;
     std::vector<sACNSource *> m_sources;

--- a/src/sacn/sacnsender.cpp
+++ b/src/sacn/sacnsender.cpp
@@ -301,6 +301,7 @@ CStreamServer::CStreamServer() :
     connect(m_thread, SIGNAL(started()), this, SLOT(TickLoop()));
     connect(m_thread, &QThread::finished, this, &QThread::deleteLater);
     this->moveToThread(m_thread);
+    m_thread->setObjectName(QString("Interface %1 TX").arg(m_sendsock->multicastInterface().name()));
     m_thread->start();
 }
 
@@ -369,6 +370,7 @@ void CStreamServer::TickLoop()
 
     while (!m_thread_stop) {
         QThread::yieldCurrentThread();
+        QCoreApplication::processEvents();
         QThread::msleep(1);
         QMutexLocker locker(&m_writeMutex);
 

--- a/src/sacn/sacnsender.cpp
+++ b/src/sacn/sacnsender.cpp
@@ -295,7 +295,7 @@ CStreamServer::CStreamServer() :
 {
     m_sendsock = new sACNTxSocket(Preferences::getInstance()->networkInterface());
 
-    m_sendsock->bindMulticast();
+    m_sendsock->bind();
 
     m_thread = new QThread();
     connect(m_thread, SIGNAL(started()), this, SLOT(TickLoop()));

--- a/src/sacn/sacnsocket.cpp
+++ b/src/sacn/sacnsocket.cpp
@@ -27,17 +27,15 @@ sACNRxSocket::sACNRxSocket(QNetworkInterface iface, QObject *parent) :
 {
 }
 
-bool sACNRxSocket::bindMulticast(quint16 universe)
+bool sACNRxSocket::bind(quint16 universe)
 {
     bool ok = false;
 
     CIPAddr addr;
     GetUniverseAddress(universe, addr);
 
-    // Bind to mutlicast address
-    ok = bind(addr.ToQHostAddress(),
-                   addr.GetIPPort(),
-                   QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint);
+    // Bind to univcast address
+    ok = bindUnicast();
 
     // Join multicast on selected NIC
     if (ok)
@@ -76,7 +74,7 @@ bool sACNRxSocket::bindUnicast()
     {
         if (ifaceAddr.ip().protocol() == QAbstractSocket::IPv4Protocol)
         {
-            ok = bind(ifaceAddr.ip(),
+            ok = QUdpSocket::bind(ifaceAddr.ip(),
                       STREAM_IP_PORT,
                       QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint);
             if (ok) {
@@ -85,7 +83,6 @@ bool sACNRxSocket::bindUnicast()
             }
         }
     }
-
 
     if (!ok) {
         close();
@@ -101,7 +98,7 @@ sACNTxSocket::sACNTxSocket(QNetworkInterface iface, QObject *parent) :
 {
 }
 
-bool sACNTxSocket::bindMulticast()
+bool sACNTxSocket::bind()
 {
     bool ok = false;
 
@@ -110,7 +107,7 @@ bool sACNTxSocket::bindMulticast()
     {
         if (ifaceAddr.ip().protocol() == QAbstractSocket::IPv4Protocol)
         {
-            ok = bind(ifaceAddr.ip());
+            ok = QUdpSocket::bind(ifaceAddr.ip());
             if (ok) {
                 setSocketOption(QAbstractSocket::MulticastLoopbackOption, QVariant(1));
                 setMulticastInterface(m_interface);

--- a/src/sacn/sacnsocket.cpp
+++ b/src/sacn/sacnsocket.cpp
@@ -20,26 +20,28 @@
 #include <QThread>
 #include "ipaddr.h"
 #include "streamcommon.h"
+#include "streamingacn.h"
+#include "sacnlistener.h"
 
 sACNRxSocket::sACNRxSocket(QNetworkInterface iface, QObject *parent) :
     QUdpSocket(parent),
     m_interface(iface)
-{
-}
+{}
 
 bool sACNRxSocket::bind(quint16 universe)
 {
+    m_universe = universe;
     bool ok = false;
 
     CIPAddr addr;
     GetUniverseAddress(universe, addr);
 
-    // Bind to univcast address
-    ok = bindUnicast();
+    ok = QUdpSocket::bind(QHostAddress::AnyIPv4,
+              STREAM_IP_PORT,
+              QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint);
 
     // Join multicast on selected NIC
-    if (ok)
-    {
+    if (ok) {
         #if (QT_VERSION <= QT_VERSION_CHECK(5, 8, 0))
             #ifdef Q_OS_WIN
                 #pragma message("setMulticastInterface() fails to bind to correct interface on systems running IPV4 and IPv6 with QT <= 5.8.0")
@@ -51,40 +53,10 @@ bool sACNRxSocket::bind(quint16 universe)
         ok |= joinMulticastGroup(QHostAddress(addr.GetV4Address()), m_interface);
     }
 
-    if(ok)
-    {
-        qDebug() << "sACNRxSocket " << QThread::currentThreadId() << ": Bound to interface:" << m_interface.name();
+    if(ok) {
+        qDebug() << "sACNRxSocket " << QThread::currentThreadId() << ": Bound to interface:" << multicastInterface().name();
         qDebug() << "sACNRxSocket " << QThread::currentThreadId() << ": Joining Multicast Group:" << QHostAddress(addr.GetV4Address()).toString();
-    }
-    else
-    {
-        close();
-        qDebug() << "sACNRxSocket " << QThread::currentThreadId() << ": Failed to bind RX socket";
-    }
-
-    return ok;
-}
-
-bool sACNRxSocket::bindUnicast()
-{
-    bool ok = false;
-
-    // Bind to first IPv4 address on selected NIC
-    foreach (QNetworkAddressEntry ifaceAddr, m_interface.addressEntries())
-    {
-        if (ifaceAddr.ip().protocol() == QAbstractSocket::IPv4Protocol)
-        {
-            ok = QUdpSocket::bind(ifaceAddr.ip(),
-                      STREAM_IP_PORT,
-                      QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint);
-            if (ok) {
-                qDebug() << "sACNRxSocket " << QThread::currentThreadId() << ": Bound to IP:" << ifaceAddr.ip().toString();
-                break;
-            }
-        }
-    }
-
-    if (!ok) {
+    } else {
         close();
         qDebug() << "sACNRxSocket " << QThread::currentThreadId() << ": Failed to bind RX socket";
     }
@@ -95,30 +67,51 @@ bool sACNRxSocket::bindUnicast()
 sACNTxSocket::sACNTxSocket(QNetworkInterface iface, QObject *parent) :
     QUdpSocket(parent),
     m_interface(iface)
-{
-}
+{}
 
 bool sACNTxSocket::bind()
 {
     bool ok = false;
 
     // Bind to first IPv4 address on selected NIC
-    foreach (QNetworkAddressEntry ifaceAddr, m_interface.addressEntries())
-    {
-        if (ifaceAddr.ip().protocol() == QAbstractSocket::IPv4Protocol)
-        {
+    foreach (QNetworkAddressEntry ifaceAddr, m_interface.addressEntries()) {
+        if (ifaceAddr.ip().protocol() == QAbstractSocket::IPv4Protocol) {
             ok = QUdpSocket::bind(ifaceAddr.ip());
             if (ok) {
-                setSocketOption(QAbstractSocket::MulticastLoopbackOption, QVariant(1));
-                setMulticastInterface(m_interface);
                 qDebug() << "sACNTxSocket " << QThread::currentThreadId() << ": Bound to IP:" << ifaceAddr.ip().toString();
+                // Don't send to self, this will cause issues on multihomed systems
+                setSocketOption(QAbstractSocket::MulticastLoopbackOption, QVariant(0));
+                setMulticastInterface(m_interface);
+                qDebug() << "sACNTxSocket " << QThread::currentThreadId() << ": Bound to interface:" << multicastInterface().name();
             }
             break;
         }
     }
-  
-    if(!ok)
-        qDebug() << "sACNTxSocket " << QThread::currentThreadId() << ": Failed to bind TX socket";
+
+    if (!ok) qDebug() << "sACNTxSocket " << QThread::currentThreadId() << ": Failed to bind TX socket";
 
     return ok;
+}
+
+qint64 sACNTxSocket::writeDatagram(const char *data, qint64 len, const QHostAddress &host, quint16 port)
+{
+    // If multicast, copy to correct internal listener(s)
+    if (host.isMulticast()) {
+        CIPAddr addr;
+        for (auto weakListener : sACNManager::getInstance()->getListenerList()) {
+            sACNManager::tListener listener(weakListener);
+            if (listener) {
+                GetUniverseAddress(listener->universe(), addr);
+                if (QHostAddress(addr.GetV4Address()) == host) {
+                    listener->processDatagram(
+                                QByteArray(data, len),
+                                QHostAddress(host),
+                                localAddress());
+                }
+            }
+        }
+    }
+
+    // Send to world
+    return QUdpSocket::writeDatagram(data, len, host, port);
 }

--- a/src/sacn/sacnsocket.h
+++ b/src/sacn/sacnsocket.h
@@ -26,10 +26,10 @@ class sACNRxSocket : public QUdpSocket
 public:
     sACNRxSocket(QNetworkInterface iface, QObject *parent = Q_NULLPTR);
 
-    bool bindMulticast(quint16 universe);
-    bool bindUnicast();
+    bool bind(quint16 universe);
 
 private:
+    bool bindUnicast();
     QNetworkInterface m_interface;
 };
 
@@ -39,7 +39,7 @@ class sACNTxSocket : public QUdpSocket
 public:
     sACNTxSocket(QNetworkInterface iface, QObject *parent = Q_NULLPTR);
 
-    bool bindMulticast();
+    bool bind();
 
 private:
     QNetworkInterface m_interface;

--- a/src/sacn/sacnsocket.h
+++ b/src/sacn/sacnsocket.h
@@ -27,10 +27,12 @@ public:
     sACNRxSocket(QNetworkInterface iface, QObject *parent = Q_NULLPTR);
 
     bool bind(quint16 universe);
+    int getBoundUniverse() { return m_universe; }
+    QNetworkInterface getBoundInterface() { return m_interface; }
 
 private:
-    bool bindUnicast();
     QNetworkInterface m_interface;
+    int m_universe;
 };
 
 class sACNTxSocket : public QUdpSocket
@@ -40,6 +42,11 @@ public:
     sACNTxSocket(QNetworkInterface iface, QObject *parent = Q_NULLPTR);
 
     bool bind();
+
+    //qint64 writeDatagram(const QNetworkDatagram &datagram);
+    qint64 writeDatagram(const char *data, qint64 len, const QHostAddress &host, quint16 port);
+    inline qint64 writeDatagram(const QByteArray &datagram, const QHostAddress &host, quint16 port)
+        { return writeDatagram(datagram.constData(), datagram.size(), host, port); }
 
 private:
     QNetworkInterface m_interface;

--- a/src/sacn/streamingacn.cpp
+++ b/src/sacn/streamingacn.cpp
@@ -60,7 +60,6 @@ sACNSource::sACNSource() :
     universe(0),
     slot_count(0),
     priority(0),
-    fpscounter(new fpsCounter(this)),
     seqErr(0),
     jumps(0)
 {

--- a/src/sacn/streamingacn.h
+++ b/src/sacn/streamingacn.h
@@ -79,7 +79,7 @@ public:
     QString name;
     QString cid_string();
     QHostAddress ip;
-    fpsCounter *fpscounter;
+    fpsCounter fpscounter;
     // The number of sequence errors from this source
     int seqErr;
     // The number of jumps (increments by anything other than 1) of this source

--- a/src/universeview.cpp
+++ b/src/universeview.cpp
@@ -151,7 +151,7 @@ void UniverseView::sourceChanged(sACNSource *source)
     else
         ui->twSources->item(row,COL_PREVIEW)->setText(source->isPreview ? tr("Yes") : tr("No"));
     ui->twSources->item(row,COL_IP)->setText(source->ip.toString());
-    ui->twSources->item(row,COL_FPS)->setText(QString("%1Hz").arg(QString::number(source->fpscounter->FPS(), 'f', 2)));
+    ui->twSources->item(row,COL_FPS)->setText(QString("%1Hz").arg(QString::number(source->fpscounter.FPS(), 'f', 2)));
     {
         // Seq Errors
         QLabel* lbl_SEQ_ERR = qobject_cast<QLabel *>(


### PR DESCRIPTION
Resolves #179 
Possible and likely cause of #167

The socket backend could receive frames multiple times, while this wouldn't have affected the resultant DMX data, it would affect the source statistics.
The socket arrangement has been altered, in particular multicast frames for display locally are passed internally and not re-received over the wire (Because Windows and Unix handle ip_multicast_loop slightly differently with multi homed machines, so this is simply disabled). Additionally the number of open sockets reduced.

This will require a good amount of testing to prove it's good. I'm unable to test on MacOS!