### PR TITLE
Add multi-grid editing

### DIFF
--- a/sACNView.pro
+++ b/sACNView.pro
@@ -104,7 +104,6 @@ SOURCES += src/main.cpp\
     src/sacn/sacnsender.cpp \
     src/configureperchanpriodlg.cpp \
     src/gridwidget.cpp \
-    src/priorityeditwidget.cpp \
     src/scopewidget.cpp \
     src/aboutdialog.cpp \
     src/sacn/sacneffectengine.cpp \
@@ -124,7 +123,8 @@ SOURCES += src/main.cpp\
     src/sacn/sacndiscovery.cpp \
     src/sacn/sacndiscoveredsourcelistmodel.cpp \
     src/clssnapshot.cpp \
-    src/sacn/fpscounter.cpp
+    src/sacn/fpscounter.cpp \
+    src/grideditwidget.cpp
 
 HEADERS += src/mdimainwindow.h \
     src/scopewindow.h \
@@ -146,7 +146,6 @@ HEADERS += src/mdimainwindow.h \
     src/sacn/sacnsender.h \
     src/configureperchanpriodlg.h \
     src/gridwidget.h \
-    src/priorityeditwidget.h \
     src/scopewidget.h \
     src/aboutdialog.h \
     src/sacn/sacneffectengine.h \
@@ -171,7 +170,8 @@ HEADERS += src/mdimainwindow.h \
     src/sacn/sacndiscovery.h \
     src/sacn/sacndiscoveredsourcelistmodel.h \
     src/clssnapshot.h \
-    src/sacn/fpscounter.h
+    src/sacn/fpscounter.h \
+    src/grideditwidget.h
 
 FORMS += ui/mdimainwindow.ui \
     ui/scopewindow.ui \

--- a/src/configureperchanpriodlg.cpp
+++ b/src/configureperchanpriodlg.cpp
@@ -68,9 +68,12 @@ quint8 *ConfigurePerChanPrioDlg::data()
 
 void ConfigurePerChanPrioDlg::on_sbPriority_valueChanged(int value)
 {
-    int currentCell = ui->widget->selectedCell();
-    if(currentCell<0) return;
-    ui->widget->setCellValue(currentCell, QString::number(value));
+    QListIterator<int>i(ui->widget->selectedCells());
+    while(i.hasNext())
+    {
+        int currentCell = i.next();
+        ui->widget->setCellValue(currentCell, QString::number(value));
+    }
     ui->widget->update();
 }
 
@@ -81,14 +84,14 @@ void ConfigurePerChanPrioDlg::on_btnSetAll_pressed()
     ui->widget->update();
 }
 
-void ConfigurePerChanPrioDlg::on_widget_selectedCellChanged(int cell)
+void ConfigurePerChanPrioDlg::on_widget_selectedCellsChanged(QList<int> cells)
 {
-    if(cell>-1)
+    if(cells.count()==1)
     {
         ui->sbPriority->setEnabled(true);
-        int iValue = ui->widget->cellValue(cell).toInt();
+        int iValue = ui->widget->cellValue(cells.first()).toInt();
         ui->sbPriority->setValue(iValue);
-        ui->lblAddress->setText(tr("Address %1, Priority = ").arg(cell+1));
+        ui->lblAddress->setText(tr("Address %1, Priority = ").arg(cells.first()+1));
     }
     else
     {

--- a/src/configureperchanpriodlg.cpp
+++ b/src/configureperchanpriodlg.cpp
@@ -42,6 +42,9 @@ ConfigurePerChanPrioDlg::ConfigurePerChanPrioDlg(QWidget *parent) :
         connect(presetButton, &QToolButton::pressed, this, &ConfigurePerChanPrioDlg::presetButtonPressed);
         m_presetButtons << presetButton;
     }
+    ui->widget->setMinimum(MIN_SACN_PRIORITY);
+    ui->widget->setMaximum(MAX_SACN_PRIORITY);
+    ui->widget->setAllValues(100);
 }
 
 ConfigurePerChanPrioDlg::~ConfigurePerChanPrioDlg()

--- a/src/configureperchanpriodlg.cpp
+++ b/src/configureperchanpriodlg.cpp
@@ -68,18 +68,6 @@ quint8 *ConfigurePerChanPrioDlg::data()
     return m_data;
 }
 
-
-void ConfigurePerChanPrioDlg::on_sbPriority_valueChanged(int value)
-{
-    QListIterator<int>i(ui->widget->selectedCells());
-    while(i.hasNext())
-    {
-        int currentCell = i.next();
-        ui->widget->setCellValue(currentCell, QString::number(value));
-    }
-    ui->widget->update();
-}
-
 void ConfigurePerChanPrioDlg::on_btnSetAll_pressed()
 {
     for(int i=0; i<512; i++)
@@ -89,18 +77,9 @@ void ConfigurePerChanPrioDlg::on_btnSetAll_pressed()
 
 void ConfigurePerChanPrioDlg::on_widget_selectedCellsChanged(QList<int> cells)
 {
-    if(cells.count()==1)
-    {
-        ui->sbPriority->setEnabled(true);
-        int iValue = ui->widget->cellValue(cells.first()).toInt();
-        ui->sbPriority->setValue(iValue);
-        ui->lblAddress->setText(tr("Address %1, Priority = ").arg(cells.first()+1));
-    }
-    else
-    {
-        ui->sbPriority->setEnabled(false);
-        ui->lblAddress->setText("");
-    }
+    ui->sbPriority->setEnabled(cells.count()>0);
+    ui->btnSet->setEnabled(cells.count()>0);
+    m_selectedCells = cells;
 }
 
 void ConfigurePerChanPrioDlg::on_btnPresetRec_toggled(bool on)
@@ -136,4 +115,12 @@ void ConfigurePerChanPrioDlg::presetButtonPressed()
         QByteArray data = Preferences::getInstance()->GetPriorityPreset(index);
         setData(reinterpret_cast<quint8 *>(data.data()));
     }
+}
+
+
+void ConfigurePerChanPrioDlg::on_btnSet_pressed()
+{
+    foreach(auto i, m_selectedCells)
+        ui->widget->setCellValue(i, QString::number(ui->sbPriority->value()));
+    ui->widget->update();
 }

--- a/src/configureperchanpriodlg.h
+++ b/src/configureperchanpriodlg.h
@@ -35,8 +35,8 @@ public:
     void setData(quint8 *data);
     quint8 *data();
 public slots:
-    void on_sbPriority_valueChanged(int value);
     void on_btnSetAll_pressed();
+    void on_btnSet_pressed();
     void on_widget_selectedCellsChanged(QList<int> cells);
     void on_btnPresetRec_toggled(bool on);
     void presetButtonPressed();
@@ -45,6 +45,7 @@ private:
     quint8 m_data[MAX_DMX_ADDRESS];
     QList<QByteArray> m_presets;
     QList<QToolButton *>m_presetButtons;
+    QList<int> m_selectedCells;
 };
 
 #endif // CONFIGUREPERCHANPRIODLG_H

--- a/src/configureperchanpriodlg.h
+++ b/src/configureperchanpriodlg.h
@@ -37,7 +37,7 @@ public:
 public slots:
     void on_sbPriority_valueChanged(int value);
     void on_btnSetAll_pressed();
-    void on_widget_selectedCellChanged(int cell);
+    void on_widget_selectedCellsChanged(QList<int> cells);
     void on_btnPresetRec_toggled(bool on);
     void presetButtonPressed();
 private:

--- a/src/grideditwidget.cpp
+++ b/src/grideditwidget.cpp
@@ -13,33 +13,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "priorityeditwidget.h"
+#include "grideditwidget.h"
 #include <QWheelEvent>
 #include "consts.h"
 
-PriorityEditWidget::PriorityEditWidget(QWidget *parent) : GridWidget(parent)
+GridEditWidget::GridEditWidget(QWidget *parent) : GridWidget(parent)
 {
-    for(int i=0; i<512; i++)
-    {
-        setCellValue(i, QString::number(DEFAULT_SACN_PRIORITY));
-    }
+    setMultiSelect(true);
 }
 
 
-void PriorityEditWidget::wheelEvent(QWheelEvent *event)
+void GridEditWidget::wheelEvent(QWheelEvent *event)
 {
     int numDegrees = event->delta() / 8;
     int numSteps = numDegrees / 15;
 
-    if(selectedCell()<0) return;
+    QList<QPair<int, int>> level_list;
 
-    int value = cellValue(selectedCell()).toInt();
-    value += numSteps;
+    QListIterator<int>i(selectedCells());
+    while(i.hasNext())
+    {
+        int cell = i.next();
+        int value = cellValue(cell).toInt();
+        value += numSteps;
 
-    if(value<MIN_SACN_PRIORITY || value>MAX_SACN_PRIORITY) return;
+        if(!(value<m_minimum || value>m_maximum))
+        {
+            setCellValue(cell, QString::number(value));
+            level_list << QPair<int,int>(cell, value);
+        }
+    }
 
-    setCellValue(selectedCell(), QString::number(value));
+    if(level_list.count()>0)
+        emit levelsSet(level_list);
+
     update();
 
     event->accept();
+}
+
+void GridEditWidget::setAllValues(int value)
+{
+    for(int i=0; i<512; i++)
+    {
+        setCellValue(i, QString::number(value));
+    }
 }

--- a/src/grideditwidget.h
+++ b/src/grideditwidget.h
@@ -13,23 +13,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef PRIORITYEDITWIDGET_H
-#define PRIORITYEDITWIDGET_H
+#ifndef GRIDEDITWIDGET_H
+#define GRIDEDITWIDGET_H
 
 #include <QObject>
 #include <QWidget>
 #include "gridwidget.h"
 
 /**
- * @brief The PriorityEditWidget class provides a widget, based on the grid widget, which allows
+ * @brief The GridEditWidget class provides a widget, based on the grid widget, which allows
  * editing of per channel priority values
  */
-class PriorityEditWidget : public GridWidget
+class GridEditWidget : public GridWidget
 {
+    Q_OBJECT
 public:
-    PriorityEditWidget(QWidget *parent = 0);
+    GridEditWidget(QWidget *parent = Q_NULLPTR);
+    void setMinimum(int min) {m_minimum = min;}
+    void setMaximum(int max) {m_maximum = max;}
+    void setAllValues(int value);
+signals:
+    void levelsSet(QList<QPair<int, int>> setLevels);
 protected:
     virtual void wheelEvent(QWheelEvent *event);
+private:
+    int m_minimum = 0;
+    int m_maximum = 100;
 };
 
-#endif // PRIORITYEDITWIDGET_H
+#endif // GRIDEDITWIDGET_H

--- a/src/gridwidget.cpp
+++ b/src/gridwidget.cpp
@@ -64,32 +64,54 @@ void GridWidget::paintEvent(QPaintEvent *event)
     qreal scaleHeight = height()/ wantedHeight;
 
     painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.scale(scaleWidth,scaleHeight);
 
-    painter.fillRect(QRectF(0,0, wantedWidth, wantedHeight), pal.color(QPalette::Base));
+    painter.fillRect(QRectF(0,0, wantedWidth*scaleWidth, wantedHeight*scaleHeight), pal.color(QPalette::Base));
 
     painter.setPen(pal.color(QPalette::Text));
-    painter.setFont(QFont("Segoe UI", 8));
+
+
+    // Determine the font size. This seems to look best based on increments of scale, not continuous scaling
+    QFont font = this->font();
+
+    if(scaleHeight<=1.2)
+        font.setPointSize(8);
+    else if(scaleHeight<1.9)
+        font.setPointSize(10);
+    else
+        font.setPointSize(12);
+    painter.setFont(font);
+
+    // Fill bars for background of the row and column labels
+    QRect rowLabelRect(0, 0,  FIRST_COL_WIDTH*scaleWidth, height());
+    painter.fillRect(rowLabelRect, QBrush(pal.color(QPalette::AlternateBase)));
+
+    QRect colLabelRect(0, 0,  width(), m_cellHeight*scaleHeight);
+    painter.fillRect(colLabelRect, QBrush(pal.color(QPalette::AlternateBase)));
+
+
     for(int row=1; row<ROW_COUNT+1; row++)
     {
-        QRect textRect(0, row*m_cellHeight, FIRST_COL_WIDTH, m_cellHeight);
-        QString rowLabel = QString("%1 - %2")
+        QRect textRect(0, row*m_cellHeight*scaleHeight, FIRST_COL_WIDTH*scaleWidth, m_cellHeight*scaleHeight);
+        QString rowLabel = QString("%1-%2")
                 .arg(1+(row-1)*32)
                 .arg((row)*32);
-        painter.drawText(textRect, rowLabel, QTextOption(Qt::AlignHCenter | Qt::AlignVCenter));
+
+        painter.drawText(textRect, Qt::AlignHCenter | Qt::AlignVCenter, rowLabel);
     }
     for(int col=0; col<COL_COUNT; col++)
     {
-        QRect textRect(FIRST_COL_WIDTH + col*CELL_WIDTH, 0, CELL_WIDTH, m_cellHeight);
+        QRect textRect((FIRST_COL_WIDTH + col*CELL_WIDTH) * scaleWidth, 0, CELL_WIDTH*scaleWidth, m_cellHeight*scaleHeight);
         QString rowLabel = QString("%1")
                 .arg(col+1);
-        painter.drawText(textRect, rowLabel, QTextOption(Qt::AlignHCenter | Qt::AlignVCenter));
+
+        painter.drawText(textRect, Qt::AlignHCenter | Qt::AlignVCenter, rowLabel);
     }
+
     for(int row=0; row<ROW_COUNT; row++)
         for(int col=0; col<COL_COUNT; col++)
         {
             int address = row*COL_COUNT + col;
-            QRect textRect(FIRST_COL_WIDTH + col*CELL_WIDTH, (row+1)*m_cellHeight, CELL_WIDTH, m_cellHeight);
+            QRect textRect((FIRST_COL_WIDTH + col*CELL_WIDTH)*scaleWidth, (row+1)*m_cellHeight*scaleHeight, CELL_WIDTH*scaleWidth, m_cellHeight*scaleHeight);
             QString value = m_values[address];
 
             if(!value.isEmpty())
@@ -98,7 +120,7 @@ void GridWidget::paintEvent(QPaintEvent *event)
 
                 QString rowLabel = value;
                 painter.fillRect(textRect, fillColor);
-                painter.drawText(textRect, rowLabel, QTextOption(Qt::AlignHCenter | Qt::AlignVCenter));
+                painter.drawText(textRect, Qt::AlignHCenter | Qt::AlignVCenter, rowLabel);
             }
 
         }
@@ -107,14 +129,14 @@ void GridWidget::paintEvent(QPaintEvent *event)
 
     for(int row=0; row<ROW_COUNT + 1; row++)
     {
-        QPoint start(0, row*m_cellHeight);
-        QPoint end(wantedWidth, row*m_cellHeight);
+        QPoint start(0, row*m_cellHeight*scaleHeight);
+        QPoint end(wantedWidth*scaleWidth, row*m_cellHeight*scaleHeight);
         painter.drawLine(start, end);
     }
     for(int col=0; col<COL_COUNT + 1; col++)
     {
-        QPoint start(FIRST_COL_WIDTH + col*CELL_WIDTH, 0);
-        QPoint end(FIRST_COL_WIDTH + col*CELL_WIDTH, wantedHeight);
+        QPoint start((FIRST_COL_WIDTH + col*CELL_WIDTH)*scaleWidth, 0);
+        QPoint end((FIRST_COL_WIDTH + col*CELL_WIDTH)*scaleWidth, wantedHeight*scaleHeight);
         painter.drawLine(start, end);
     }
 
@@ -125,7 +147,7 @@ void GridWidget::paintEvent(QPaintEvent *event)
         int selectedAddress = i.next();
         int col = selectedAddress % 32;
         int row = selectedAddress / 32;
-        QRect textRect(FIRST_COL_WIDTH + col*CELL_WIDTH, (row+1)*m_cellHeight, CELL_WIDTH, m_cellHeight);
+        QRect textRect((FIRST_COL_WIDTH + col*CELL_WIDTH)*scaleWidth, (row+1)*m_cellHeight*scaleHeight, CELL_WIDTH*scaleWidth, m_cellHeight*scaleHeight);
         painter.setPen(pal.color(QPalette::Highlight));
         painter.drawRect(textRect);
     }

--- a/src/gridwidget.h
+++ b/src/gridwidget.h
@@ -65,6 +65,7 @@ protected:
     virtual void mouseMoveEvent(QMouseEvent *event) override;
     virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
     virtual bool event(QEvent *event) override;
+    virtual void keyPressEvent(QKeyEvent *event) override;
 
     // Returns the cell under point, -1 for none
     int cellHitTest(const QPoint &point);
@@ -74,6 +75,7 @@ private:
     QVector<QColor> m_colors;
     QStringList m_values;
     bool m_allowMultiSelect = false;
+    QPoint m_lastClickPoint;
 protected:
     int m_cellHeight;
 };

--- a/src/gridwidget.h
+++ b/src/gridwidget.h
@@ -17,6 +17,7 @@
 #define GRIDWIDGET_H
 
 #include <QWidget>
+#include <QList>
 
 /**
  * @brief The GridWidget class provides a control for a grid of 512 numeric values, with
@@ -26,7 +27,7 @@ class GridWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit GridWidget(QWidget *parent = 0);
+    explicit GridWidget(QWidget *parent = Q_NULLPTR);
 
     void setCellColor(int cell, const QColor &color);
     /**
@@ -45,28 +46,34 @@ public:
      * @brief selectedCell returns the currently selected cell, or -1 if no cell is selected
      * @return the selected cell, or -1 if no cell selected
      */
-    int selectedCell() const { return m_selectedAddress; }
+    QList<int> selectedCells() const { return m_selectedAddresses; }
+    /**
+      * @brief setMultiSelect sets whether multiple cells can be selected at once
+      **/
+    void setMultiSelect(bool value) {m_allowMultiSelect = value;}
 signals:
     // The user changed the selected address. -1 means no selected address
-    void selectedCellChanged(int cell);
+    void selectedCellsChanged(QList<int> selectedCells);
     // User double clicked on a cell.
     void cellDoubleClick(quint16 address);
 
 protected:
-    virtual void paintEvent(QPaintEvent *event);
-    virtual QSize minimumSizeHint() const;
-    virtual QSize sizeHint() const;
-    virtual void mousePressEvent(QMouseEvent *event);
-    virtual void mouseMoveEvent(QMouseEvent *event);
-    virtual void mouseDoubleClickEvent(QMouseEvent *event);
+    virtual void paintEvent(QPaintEvent *event) override;
+    virtual QSize minimumSizeHint() const override;
+    virtual QSize sizeHint() const override;
+    virtual void mousePressEvent(QMouseEvent *event) override;
+    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+    virtual bool event(QEvent *event) override;
 
     // Returns the cell under point, -1 for none
     int cellHitTest(const QPoint &point);
 
 private:
-    int m_selectedAddress;
+    QList<int> m_selectedAddresses;
     QVector<QColor> m_colors;
     QStringList m_values;
+    bool m_allowMultiSelect = false;
 protected:
     int m_cellHeight;
 };

--- a/src/theme/darkstyle.cpp
+++ b/src/theme/darkstyle.cpp
@@ -87,13 +87,13 @@ void DarkStyle::polish(QPalette &palette)
 {
     // modify palette to dark
     palette.setColor(QPalette::Window,QColor(53,53,53));
-    palette.setColor(QPalette::WindowText,Qt::white);
+    palette.setColor(QPalette::WindowText,QColor("#e2e2e2"));
     palette.setColor(QPalette::Disabled,QPalette::WindowText,QColor(127,127,127));
     palette.setColor(QPalette::Base,QColor(42,42,42));
     palette.setColor(QPalette::AlternateBase,QColor(66,66,66));
-    palette.setColor(QPalette::ToolTipBase,Qt::white);
-    palette.setColor(QPalette::ToolTipText,Qt::white);
-    palette.setColor(QPalette::Text,Qt::white);
+    palette.setColor(QPalette::ToolTipBase,QColor("#e2e2e2"));
+    palette.setColor(QPalette::ToolTipText,QColor("#e2e2e2"));
+    palette.setColor(QPalette::Text,QColor("#e2e2e2"));
     palette.setColor(QPalette::Disabled,QPalette::Text,QColor(127,127,127));
     palette.setColor(QPalette::Dark,QColor(35,35,35));
     palette.setColor(QPalette::Shadow,QColor(20,20,20));

--- a/src/transmitwindow.h
+++ b/src/transmitwindow.h
@@ -37,7 +37,7 @@ class transmitwindow : public QWidget
     Q_OBJECT
 
 public:
-    explicit transmitwindow(int universe = MIN_SACN_UNIVERSE, QWidget *parent = 0);
+    explicit transmitwindow(int universe = MIN_SACN_UNIVERSE, QWidget *parent = Q_NULLPTR);
     ~transmitwindow();
     static const int BLINK_TIME = 1000;
     static const int NUM_SLIDERS = 24;
@@ -70,6 +70,7 @@ protected slots:
     void setLevels(QSet<int> addresses, int level);
     void dateMode_toggled(int id, bool checked);
     void sourceTimeout();
+    void setLevelList(QList<QPair<int, int>> levelList);
 private slots:
     void on_rbDraft_clicked();
 
@@ -88,6 +89,7 @@ private:
     void setUniverseOptsEnabled(bool enabled);
     void updateTitle();
     void updateEnabled();
+    void setLevel(int address, int value);
     Ui::transmitwindow *ui;
     QList<QSlider *> m_sliders;
     QList<QLabel *> m_sliderLabels;

--- a/src/universeview.cpp
+++ b/src/universeview.cpp
@@ -55,7 +55,7 @@ UniverseView::UniverseView(int universe, QWidget *parent) :
     m_displayDDOnlySource = Preferences::getInstance()->GetDisplayDDOnly();
 
     ui->setupUi(this);
-    connect(ui->universeDisplay, SIGNAL(selectedCellChanged(int)), this, SLOT(selectedAddressChanged(int)));
+    connect(ui->universeDisplay, SIGNAL(selectedCellsChanged(QList<int>)), this, SLOT(selectedAddressesChanged(QList<int>)));
     connect(ui->universeDisplay, SIGNAL(cellDoubleClick(quint16)), this, SLOT(openBigDisplay(quint16)));
 
     connect(ui->btnShowPriority, &QPushButton::toggled,
@@ -398,4 +398,13 @@ void UniverseView::on_btnLogWindow_pressed()
     if(!mainWindow) return;
     LogWindow *w = new LogWindow(ui->sbUniverse->value(),mainWindow);
     mainWindow->showWidgetAsMdiWindow(w);
+}
+
+
+void UniverseView::selectedAddressesChanged(QList<int> addresses)
+{
+    if(addresses.count()==0)
+        selectedAddressChanged(-1);
+    if(addresses.count()==1)
+        selectedAddressChanged(addresses.first());
 }

--- a/src/universeview.h
+++ b/src/universeview.h
@@ -44,6 +44,7 @@ protected slots:
     void sourceChanged(sACNSource *source);
     void levelsChanged();
     void selectedAddressChanged(int address);
+    void selectedAddressesChanged(QList<int> addresses);
     void openBigDisplay(quint16 address);
     void on_btnStartFlickerFinder_pressed();
     void on_btnLogWindow_pressed();

--- a/ui/configureperchanpriodlg.ui
+++ b/ui/configureperchanpriodlg.ui
@@ -17,13 +17,6 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="lblAddress">
-       <property name="text">
-        <string>Address ?, Priority = </string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QSpinBox" name="sbPriority">
        <property name="minimumSize">
         <size>
@@ -33,6 +26,13 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSet">
+       <property name="text">
+        <string>Set</string>
        </property>
       </widget>
      </item>

--- a/ui/configureperchanpriodlg.ui
+++ b/ui/configureperchanpriodlg.ui
@@ -108,7 +108,7 @@
     </layout>
    </item>
    <item>
-    <widget class="PriorityEditWidget" name="widget" native="true">
+    <widget class="GridEditWidget" name="widget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -131,9 +131,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PriorityEditWidget</class>
+   <class>GridEditWidget</class>
    <extends>QWidget</extends>
-   <header>priorityeditwidget.h</header>
+   <header>grideditwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/ui/transmitwindow.ui
+++ b/ui/transmitwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>903</width>
-    <height>690</height>
+    <width>1193</width>
+    <height>693</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -527,7 +527,7 @@ border-radius: 4px;
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="tab">
+      <widget class="QWidget" name="tabFaders">
        <attribute name="title">
         <string>Faders</string>
        </attribute>
@@ -1218,7 +1218,7 @@ border-radius: 4px;
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="tab_3">
+      <widget class="QWidget" name="tabChanCheck">
        <attribute name="title">
         <string>Channel Check</string>
        </attribute>
@@ -1398,7 +1398,7 @@ color: rgb(255, 85, 0);</string>
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="tab_4">
+      <widget class="QWidget" name="tabFadeRange">
        <attribute name="title">
         <string>Fade Range</string>
        </attribute>
@@ -1601,6 +1601,20 @@ color: rgb(255, 85, 0);</string>
                  </widget>
                 </item>
                </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="rbVerticalBars">
+               <property name="text">
+                <string>Vertical Bars</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="rbHorizBars">
+               <property name="text">
+                <string>Horizontal Bars</string>
+               </property>
               </widget>
              </item>
              <item>
@@ -1875,12 +1889,28 @@ color: rgb(255, 85, 0);</string>
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tabGridControl">
+       <attribute name="title">
+        <string>Grid Control</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_13">
+        <item>
+         <widget class="GridEditWidget" name="gridControl" native="true"/>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>GridEditWidget</class>
+   <extends>QWidget</extends>
+   <header>grideditwidget.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>CommandLineWidget</class>
    <extends>QPlainTextEdit</extends>


### PR DESCRIPTION
Create a multi-editable version of the grid widget for editing per-address priorities, and additionally as another way to set levels. Addresses #183