### PR TITLE
Fix macos build and add code signing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         osx_image: xcode9.4
         before_install:
           - chmod +x install/mac/sign-mac-executable.sh
-          - ./install/mac/sign-max-executable.sh
+          - ./install/mac/sign-mac-executable.sh
           - brew update
         install:
           # PCap

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
           - echo "Uploading $BASENAME to file.io..." && curl -sF "file=@$FILE" https://file.io | xargs printf "$BASENAME uploaded - %s\n"
 
       - os: osx
-        osx_image: xcode9.4
+        osx_image: xcode10.2
         before_install:
           - brew update
         install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,10 @@ matrix:
           - echo "Uploading $BASENAME to file.io..." && curl -sF "file=@$FILE" https://file.io | xargs printf "$BASENAME uploaded - %s\n"
 
       - os: osx
-        osx_image: xcode10.2
+        osx_image: xcode9.4
         before_install:
+          - chmod +x install/mac/sign-mac-executable.sh
+          - ./install/mac/sign-max-executable.sh
           - brew update
         install:
           # PCap

--- a/deploy.pri
+++ b/deploy.pri
@@ -45,9 +45,9 @@ macx {
     DEPLOY_TARGET = $${OUT_PWD}/$${TARGET}$${TARGET_CUSTOM_EXT}
 
     DEPLOY_COMMAND = macdeployqt
-    DEPLOY_OPT = -codesign=\"Thomas Steer\"
 
-    DEPLOY_CLEANUP = $${QMAKE_DEL_FILE} $${DEPLOY_DIR}/sACNView*.dmg
+    DEPLOY_CLEANUP = codesign --force --verify --verbose --sign "Thomas Steer" $${DEPLOY_TARGET} $$escape_expand(\\n\\t)
+    DEPLOY_CLEANUP += $${QMAKE_DEL_FILE} $${DEPLOY_DIR}/sACNView*.dmg
 
     DEPLOY_INSTALLER = $${_PRO_FILE_PWD_}/install/mac/create-dmg --volname "sACNView_Installer" --volicon "$${_PRO_FILE_PWD_}/res/icon.icns"
     DEPLOY_INSTALLER += --background "$${_PRO_FILE_PWD_}/res/mac_install_bg.png" --window-pos 200 120 --window-size 800 400 --icon-size 100 --icon $${TARGET}$${TARGET_CUSTOM_EXT} 200 190 --hide-extension $${TARGET}$${TARGET_CUSTOM_EXT} --app-drop-link 600 185

--- a/deploy.pri
+++ b/deploy.pri
@@ -45,6 +45,7 @@ macx {
     DEPLOY_TARGET = $${OUT_PWD}/$${TARGET}$${TARGET_CUSTOM_EXT}
 
     DEPLOY_COMMAND = macdeployqt
+    DEPLOY_OPT = -codesign="Developer ID Application: Thomas Steer"
 
     DEPLOY_CLEANUP = $${QMAKE_DEL_FILE} $${DEPLOY_DIR}/sACNView*.dmg
 

--- a/deploy.pri
+++ b/deploy.pri
@@ -45,7 +45,7 @@ macx {
     DEPLOY_TARGET = $${OUT_PWD}/$${TARGET}$${TARGET_CUSTOM_EXT}
 
     DEPLOY_COMMAND = macdeployqt
-    DEPLOY_OPT = -codesign="Developer ID Application: Thomas Steer"
+    DEPLOY_OPT = -codesign=\"Thomas Steer\"
 
     DEPLOY_CLEANUP = $${QMAKE_DEL_FILE} $${DEPLOY_DIR}/sACNView*.dmg
 

--- a/deploy.pri
+++ b/deploy.pri
@@ -46,7 +46,7 @@ macx {
 
     DEPLOY_COMMAND = macdeployqt
 
-    DEPLOY_CLEANUP = codesign --force --verify --verbose --sign "Thomas Steer" $${DEPLOY_TARGET} $$escape_expand(\\n\\t)
+    DEPLOY_CLEANUP = codesign --force --deep --verify --verbose --sign \"Thomas Steer\" $${DEPLOY_TARGET} $$escape_expand(\\n\\t)
     DEPLOY_CLEANUP += $${QMAKE_DEL_FILE} $${DEPLOY_DIR}/sACNView*.dmg
 
     DEPLOY_INSTALLER = $${_PRO_FILE_PWD_}/install/mac/create-dmg --volname "sACNView_Installer" --volicon "$${_PRO_FILE_PWD_}/res/icon.icns"

--- a/install/mac/sign-mac-executable.sh
+++ b/install/mac/sign-mac-executable.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+# Adapted from https://www.update.rocks/blog/osx-signing-with-travis/
+# Uses a base64 encoded certificate in an environment variable to set up signing
+# Exits if the variable isn't set
+
+KEY_CHAIN=build.keychain
+CERTIFICATE_P12=certificate.p12
+
+# Check for the variable
+if [ -z ${CERTIFICATE_OSX_P12+x} ]; then
+ echo "No macos signing setup - output will be unsigned"
+ exit
+else
+ echo "macos signing is setup - output will be signed"
+fi
+
+# Recreate the certificate from the secure environment variable
+echo $CERTIFICATE_OSX_P12 | base64 --decode > $CERTIFICATE_P12
+
+#create a keychain
+security create-keychain -p travis $KEY_CHAIN
+
+# Make the keychain the default so identities are found
+security default-keychain -s $KEY_CHAIN
+
+# Unlock the keychain
+security unlock-keychain -p travis $KEY_CHAIN
+
+security import $CERTIFICATE_P12 -k $KEY_CHAIN -P $CERTIFICATE_PASSWORD -T /usr/bin/codesign;
+
+security set-key-partition-list -S apple-tool:,apple: -s -k travis $KEY_CHAIN
+
+# remove certs
+rm -fr *.p12

--- a/install/mac/sign-mac-executable.sh
+++ b/install/mac/sign-mac-executable.sh
@@ -3,7 +3,7 @@
 # Uses a base64 encoded certificate in an environment variable to set up signing
 # Exits if the variable isn't set
 
-KEY_CHAIN=build.keychain
+KEY_CHAIN=buildtest2.keychain
 CERTIFICATE_P12=certificate.p12
 
 # Check for the variable
@@ -25,6 +25,9 @@ security default-keychain -s $KEY_CHAIN
 
 # Unlock the keychain
 security unlock-keychain -p travis $KEY_CHAIN
+
+# Set keychain locking timeout to 1 hour
+security set-keychain-settings -t 3600 -u $KEY_CHAIN
 
 security import $CERTIFICATE_P12 -k $KEY_CHAIN -P $CERTIFICATE_PASSWORD -T /usr/bin/codesign;
 

--- a/sACNView.pro
+++ b/sACNView.pro
@@ -23,7 +23,6 @@ URL = $$shell_quote("https://docsteer.github.io/sacnview/")
 LICENSE = $$shell_quote("Apache 2.0")
 
 macx {
-    QMAKE_MAC_SDK = macosx10.12
     ICON = res/icon.icns
 }
 


### PR DESCRIPTION
- Remove the mac SDK force (just use what's available)
- Add a post-build code signing step. This uses dedicated environment variables in Travis to contain the certificate and password for the build. If the variables aren't present, it just builds an unsigned version