### PR TITLE
Multicast TTL

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -283,6 +283,8 @@ void Preferences::savePreferences()
         settings.setValue(S_PRIORITYPRESET.arg(i), QVariant(m_priorityPresets[i]));
     }
 
+    settings.setValue(S_MULTICASTTTL, m_multicastTtl);
+
     settings.sync();
 }
 
@@ -318,6 +320,7 @@ void Preferences::loadPreferences()
     m_txrateoverride = settings.value(S_TX_RATE_OVERRIDE, QVariant(false)).toBool();
     m_locale = settings.value(S_LOCALE, QLocale::system()).toLocale();
     m_universesListed = settings.value(S_UNIVERSESLISTED, QVariant(20)).toUInt();
+    m_multicastTtl = settings.value(S_MULTICASTTTL, QVariant(1)).toUInt();
 
     m_windowInfo.clear();
     int size = settings.beginReadArray(S_SUBWINDOWLIST);

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -47,6 +47,7 @@ static const QString S_TX_RATE_OVERRIDE("TX Rate Override");
 static const QString S_LOCALE("LOCALE");
 static const QString S_UNIVERSESLISTED("Universe List Count");
 static const QString S_PRIORITYPRESET("PriorityPreset %1");
+static const QString S_MULTICASTTTL("Multicast TTL");
 
 struct MDIWindowInfo
 {
@@ -125,6 +126,7 @@ public:
     void SetLocale(QLocale locale);
     void SetUniversesListed(quint8 count) { m_universesListed = (std::max)(count, (quint8)1); }
     void SetPriorityPreset(const QByteArray &data, int index);
+    void SetMulticastTtl(quint8 ttl) { m_multicastTtl = ttl;}
 
     unsigned int GetDisplayFormat();
     unsigned int GetMaxLevel();
@@ -142,6 +144,7 @@ public:
     bool GetTXRateOverride() { return m_txrateoverride; }
     QLocale GetLocale();
     quint8 GetUniversesListed() { return m_universesListed; }
+    quint8 GetMulticastTtl() { return m_multicastTtl; }
 
     QString GetFormattedValue(unsigned int nLevelInDecimal, bool decorated = false);
     QByteArray GetPriorityPreset(int index);
@@ -173,6 +176,7 @@ private:
     QLocale m_locale;
     quint8 m_universesListed;
     QByteArray m_priorityPresets[PRIORITYPRESET_COUNT];
+    quint8 m_multicastTtl;
 
     void loadPreferences();
 };

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -101,6 +101,8 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
     ui->cbTheme->clear();
     ui->cbTheme->addItems(Preferences::ThemeDescriptions());
     ui->cbTheme->setCurrentIndex(static_cast<int>(Preferences::getInstance()->GetTheme()));
+
+    ui->sbMulticastTtl->setValue(Preferences::getInstance()->GetMulticastTtl());
 }
 
 PreferencesDialog::~PreferencesDialog()
@@ -177,6 +179,13 @@ void PreferencesDialog::on_buttonBox_accepted()
     if (m_translation->GetSelectedLocale() != p->GetLocale())
     {
         p->SetLocale(m_translation->GetSelectedLocale());
+        requiresRestart = true;
+    }
+
+    // Multicast TTL
+    if(p->GetMulticastTtl() != ui->sbMulticastTtl->value())
+    {
+        p->SetMulticastTtl(ui->sbMulticastTtl->value());
         requiresRestart = true;
     }
 

--- a/src/sacn/sacnsocket.cpp
+++ b/src/sacn/sacnsocket.cpp
@@ -22,6 +22,7 @@
 #include "streamcommon.h"
 #include "streamingacn.h"
 #include "sacnlistener.h"
+#include "preferences.h"
 
 sACNRxSocket::sACNRxSocket(QNetworkInterface iface, QObject *parent) :
     QUdpSocket(parent),
@@ -98,7 +99,7 @@ bool sACNTxSocket::bind()
                 setSocketOption(QAbstractSocket::MulticastLoopbackOption, QVariant(0));
 #endif
 
-                setSocketOption(QAbstractSocket::MulticastTtlOption, QVariant(60));
+                setSocketOption(QAbstractSocket::MulticastTtlOption, QVariant(Preferences::getInstance()->GetMulticastTtl()));
 
                 setMulticastInterface(m_interface);
                 qDebug() << "sACNTxSocket " << QThread::currentThreadId() << ": Bound to interface:" << multicastInterface().name();

--- a/src/sacn/sacnsocket.cpp
+++ b/src/sacn/sacnsocket.cpp
@@ -98,6 +98,8 @@ bool sACNTxSocket::bind()
                 setSocketOption(QAbstractSocket::MulticastLoopbackOption, QVariant(0));
 #endif
 
+                setSocketOption(QAbstractSocket::MulticastTtlOption, QVariant(60));
+
                 setMulticastInterface(m_interface);
                 qDebug() << "sACNTxSocket " << QThread::currentThreadId() << ": Bound to interface:" << multicastInterface().name();
             }

--- a/ui/preferencesdialog.ui
+++ b/ui/preferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>639</width>
-    <height>452</height>
+    <width>653</width>
+    <height>491</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -256,52 +256,54 @@
        <property name="title">
         <string>Transmit Options</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_6" stretch="1,0,0">
-        <item>
-         <widget class="QGroupBox" name="gbTransmitName">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="title">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
            <string>Default Source Name</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_5">
-           <item>
-            <widget class="QLineEdit" name="leDefaultSourceName">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maxLength">
-              <number>63</number>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-          </layout>
          </widget>
         </item>
-        <item>
-         <widget class="QCheckBox" name="cbTxRateOverride">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Multicast TTL*</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QSpinBox" name="sbMulticastTtl">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text">
-           <string>Allow rates to exceed E1.11 (E1.31:2016 6.6.1)*</string>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>255</number>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QLineEdit" name="leDefaultSourceName">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maxLength">
+           <number>63</number>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0" colspan="3">
          <widget class="QGroupBox" name="gbTransmitTimeout">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -435,6 +437,19 @@
             </layout>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="3">
+         <widget class="QCheckBox" name="cbTxRateOverride">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Allow rates to exceed E1.11 (E1.31:2016 6.6.1)*</string>
+          </property>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
Adds a preference option for the TTL of multicast datagrams which are sent by the application. It was discovered in a routed system that our TTL of 1(default) was causing traffic not to be routed.