### PR TITLE
Respect dark mode in Flicker Finder

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -121,11 +121,5 @@ static const unsigned char PTOHT[] =
 static const QList<qreal> FX_FADE_RATES({
  0.5,1,2,5,10,25,44,50,75,100,500});
 
-
-static const QColor flickerHigherColor  = QColor::fromRgb(0x8d, 0x32, 0xfd);
-static const QColor flickerLowerColor   = QColor::fromRgb(0x04, 0xfd, 0x44);
-static const QColor flickerChangedColor = QColor::fromRgb(0xfb, 0x09, 0x09);
-
-
 #endif // CONSTS_H
 

--- a/src/ui/flickerfinderinfoform.cpp
+++ b/src/ui/flickerfinderinfoform.cpp
@@ -15,20 +15,20 @@
 
 #include "flickerfinderinfoform.h"
 #include "ui_flickerfinderinfoform.h"
-#include "consts.h"
+#include "universedisplay.h"
 #include "preferences.h"
 
-FlickerFinderInfoForm::FlickerFinderInfoForm(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::FlickerFinderInfoForm)
+FlickerFinderInfoForm::FlickerFinderInfoForm(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::FlickerFinderInfoForm)
 {
     ui->setupUi(this);
     QPalette p = ui->wLower->palette();
-    p.setColor(QPalette::Window,    flickerLowerColor);
+    p.setColor(QPalette::Window, UniverseDisplay::flickerLowerColor());
     ui->wLower->setPalette(p);
-    p.setColor(QPalette::Window,    flickerHigherColor);
+    p.setColor(QPalette::Window, UniverseDisplay::flickerHigherColor());
     ui->wHigher->setPalette(p);
-    p.setColor(QPalette::Window,    flickerChangedColor);
+    p.setColor(QPalette::Window, UniverseDisplay::flickerChangedColor());
     ui->wChange->setPalette(p);
 }
 

--- a/src/widgets/universedisplay.cpp
+++ b/src/widgets/universedisplay.cpp
@@ -34,6 +34,50 @@ void UniverseDisplay::setShowChannelPriority(bool enable)
     levelsChanged();
 }
 
+const QColor &UniverseDisplay::flickerHigherColor()
+{
+    switch (Preferences::Instance().GetTheme()) {
+    default:
+    case Themes::LIGHT: {
+        static const QColor highLight(0x8d, 0x32, 0xfd);
+        return highLight;
+    }
+    case Themes::DARK:
+        static const QColor highDark(0x46, 0x19, 0x7e);
+        return highDark;
+    }
+}
+
+const QColor &UniverseDisplay::flickerLowerColor()
+{
+    switch (Preferences::Instance().GetTheme()) {
+    default:
+    case Themes::LIGHT: {
+        static const QColor lowLight(0x04, 0xfd, 0x44);
+        return lowLight;
+    }
+    case Themes::DARK: {
+        static const QColor lowDark(0x02, 0x7e, 0x22);
+        return lowDark;
+    }
+    }
+}
+
+const QColor &UniverseDisplay::flickerChangedColor()
+{
+    switch (Preferences::Instance().GetTheme()) {
+    default:
+    case Themes::LIGHT: {
+        static const QColor changeLight(0xfb, 0x09, 0x09);
+        return changeLight;
+    }
+    case Themes::DARK: {
+        static const QColor changeDark(0x7d, 0x04, 0x04);
+        return changeDark;
+    }
+    }
+}
+
 void UniverseDisplay::setUniverse(int universe)
 {
     // Don't search if we have already found, eg pause-continue
@@ -75,21 +119,17 @@ void UniverseDisplay::levelsChanged()
             {
                 if(m_sources[i].level > m_flickerFinderLevels[i])
                 {
-                    setCellColor(i, flickerHigherColor);
+                    setCellColor(i, flickerHigherColor());
                     m_flickerFinderHasChanged[i] = true;
                 }
                 else if( m_sources[i].level < m_flickerFinderLevels[i])
                 {
-                    setCellColor(i, flickerLowerColor);
+                    setCellColor(i, flickerLowerColor());
                     m_flickerFinderHasChanged[i] = true;
                 }
                 else if(m_flickerFinderHasChanged[i])
                 {
-                    setCellColor(i, flickerChangedColor);
-                }
-                else
-                {
-                    setCellColor(i, Qt::white);
+                    setCellColor(i, flickerChangedColor());
                 }
             }
             else
@@ -99,7 +139,7 @@ void UniverseDisplay::levelsChanged()
         }
         else
         {
-            setCellColor(i, Qt::white);
+            setCellColor(i, Preferences::Instance().GetTheme() == Themes::LIGHT ? Qt::white : Qt::black);
             setCellValue(i, QString());
         }
     }
@@ -117,7 +157,7 @@ void UniverseDisplay::setFlickerFinder(bool on)
         {
             m_flickerFinderLevels[i] = m_listener->mergedLevels().at(i).level;
             m_flickerFinderHasChanged[i] = false;
-            setCellColor(i, Qt::white);
+            setCellColor(i, Preferences::Instance().GetTheme() == Themes::LIGHT ? Qt::white : Qt::black);
         }
     }
     else

--- a/src/widgets/universedisplay.h
+++ b/src/widgets/universedisplay.h
@@ -45,6 +45,10 @@ public:
     Q_SLOT void setShowChannelPriority(bool enable);
     Q_SIGNAL void showChannelPriorityChanged(bool enable);
 
+    static const QColor &flickerHigherColor();
+    static const QColor &flickerLowerColor();
+    static const QColor &flickerChangedColor();
+
 public slots:
     void pause();
 


### PR DESCRIPTION
Don't hardcode the colors, especially white background.

Flicker Finder was almost unusable in Dark Mode!