### PR TITLE
Windows installer is now 64bit, update path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,10 @@ jobs:
             installer_setup: |
               Invoke-WebRequest -Uri "https://nsis.sourceforge.io/mediawiki/images/e/e0/NSIS_Simple_Firewall_Plugin_Unicode_1.21.zip" -OutFile "NSIS_Simple_Firewall_Plugin_Unicode.zip"
               7z e NSIS_Simple_Firewall_Plugin_Unicode.zip -o"C:\Program Files (x86)\NSIS\Plugins\x86-unicode"
-            arch: win32_msvc2019
+            arch: win64_msvc2019
             make_cmd: nmake
             artifact: |
-              install/win/sACNView*.exe
+              install/win64/sACNView*.exe
               release/*.pdb 
 
           - os: macos-latest


### PR DESCRIPTION
The Windows build has been 64bit since Qt 6.2.4 if not earlier.
Update the github action to upload the Win64 installer