### PR TITLE
Add ability to compare levels between two universes

### DIFF
--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -291,8 +291,12 @@ QString Preferences::GetUpdateIgnore() const
   return settings.value(S_UPDATE_IGNORE, QString()).toString();
 }
 
-QString Preferences::GetFormattedValue(unsigned int nLevelInDecimal, bool decorated) const
+QString Preferences::GetFormattedValue(int nLevelInDecimal, bool decorated) const
 {
+  // Negative means "none"
+  if (nLevelInDecimal < 0)
+    return QStringLiteral("---");
+
   Q_ASSERT(nLevelInDecimal <= 255);
 
   switch (m_nDisplayFormat)

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -172,7 +172,7 @@ public:
   bool GetRestartPending() const { return m_restartPending; }
   void SetRestartPending() { m_restartPending = true; }
 
-  QString GetFormattedValue(unsigned int nLevelInDecimal, bool decorated = false) const;
+  QString GetFormattedValue(int nLevelInDecimal, bool decorated = false) const;
 
   void savePreferences() const;
 

--- a/src/ui/universeview.h
+++ b/src/ui/universeview.h
@@ -52,9 +52,14 @@ protected slots:
     void selectedAddressesChanged(QList<int> addresses);
     void openBigDisplay(quint16 address);
     void on_btnStartFlickerFinder_clicked();
+    void on_btnCompareUniverse_clicked();
+    void on_sbCompareUniverse_editingFinished();
     void on_btnLogWindow_clicked();
     void on_btnExportSourceList_clicked();
     void listenerStarted(int universe);
+
+    void onFlickerFinderChanged();
+    void onCompareUniverseChanged();
 
 protected:
     virtual void resizeEvent(QResizeEvent *event);
@@ -64,6 +69,8 @@ private:
     void resizeColumns();
     bool m_bindWarningShown = false;
     void checkBind();
+
+    void updateButtons(bool running);
 
     QString prioText(const sACNSource *source, quint8 address) const;
 

--- a/src/widgets/gridwidget.cpp
+++ b/src/widgets/gridwidget.cpp
@@ -335,6 +335,11 @@ void GridWidget::mouseDoubleClickEvent(QMouseEvent *event)
     }
 }
 
+void GridWidget::setAllCellColor(const QColor& color)
+{
+  m_colors.fill(color);
+}
+
 void GridWidget::setCellColor(int cell, const QColor &color)
 {
     m_colors[cell] = color;

--- a/src/widgets/gridwidget.h
+++ b/src/widgets/gridwidget.h
@@ -29,6 +29,7 @@ class GridWidget : public QWidget
 public:
     explicit GridWidget(QWidget *parent = Q_NULLPTR);
 
+    void setAllCellColor(const QColor& color);
     void setCellColor(int cell, const QColor &color);
     /**
      * @brief setCellValue - sets the value for a cell

--- a/ui/universeview.ui
+++ b/ui/universeview.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>878</width>
-    <height>490</height>
+    <width>872</width>
+    <height>494</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,6 +18,18 @@
     <normaloff>:/icons/univ_view.png</normaloff>:/icons/univ_view.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
    <item>
     <widget class="QSplitter" name="splitter_2">
      <property name="sizePolicy">
@@ -55,14 +67,29 @@
        </size>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0" colspan="3">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Universe</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
              </property>
             </widget>
            </item>
@@ -115,7 +142,7 @@
            </item>
           </layout>
          </item>
-         <item>
+         <item row="1" column="0" colspan="3">
           <widget class="QPushButton" name="btnShowPriority">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -131,20 +158,7 @@
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QPushButton" name="btnStartFlickerFinder">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Start Flicker Finder</string>
-           </property>
-          </widget>
-         </item>
-         <item>
+         <item row="4" column="0" colspan="3">
           <widget class="QPushButton" name="btnLogWindow">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -157,10 +171,64 @@
            </property>
           </widget>
          </item>
-         <item>
+         <item row="3" column="0">
+          <widget class="QPushButton" name="btnCompareUniverse">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Compare levels with another universe</string>
+           </property>
+           <property name="text">
+            <string>Start Compare Univ</string>
+           </property>
+           <property name="checkable">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QSpinBox" name="sbCompareUniverse">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>63999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="3">
           <widget class="QPushButton" name="btnExportSourceList">
            <property name="text">
             <string>Export Source List...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="QPushButton" name="btnStartFlickerFinder">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Start Flicker Finder</string>
+           </property>
+           <property name="checkable">
+            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -179,7 +247,7 @@
          </property>
          <widget class="QTableView" name="tableView">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -239,7 +307,7 @@
       <property name="sizePolicy">
        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
         <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
+        <verstretch>1</verstretch>
        </sizepolicy>
       </property>
       <property name="minimumSize">


### PR DESCRIPTION
Allows comparisons between different controllers that are expected to have the same output levels
eg when transferring a show between different consoles using USITT ASCII

Shows both sets of levels
Uses the same colors as the flicker finder