### PR TITLE
Add .qtc_clangd/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Qt-es
 /.qmake.cache
 /.qmake.stash
+.qtc_clangd/*
 *.pro.user
 *.pro.user.*
 *.qbs.user


### PR DESCRIPTION
Qt Creator 13 has started using this temporary folder