### PR TITLE
Work around a breakpad bug on Windows

### DIFF
--- a/libs.pri
+++ b/libs.pri
@@ -28,9 +28,7 @@ win32 {
     DEFINES += USE_BREAKPAD
 
     # Config breakpad if required
-    system(if not exist $$shell_quote($${BREAKPAD_PATH}) ( mkdir $$shell_quote($${BREAKPAD_PATH}) && cd $$shell_quote($${BREAKPAD_PATH}) && $$shell_quote($${DEPOT_TOOLS_PATH}\fetch.bat) breakpad))
-    # Update Breakpad
-    system(cd $$shell_quote($${BREAKPAD_PATH}) && $$shell_quote($${DEPOT_TOOLS_PATH}\gclient.bat) sync)
+    system(set "PATH=$${DEPOT_TOOLS_PATH};%PATH%" && $${LIBS_PATH}/update_breakpad_win.bat)
 
     LIBS += -luser32
     INCLUDEPATH  += {BREAKPAD_PATH}/src/src/

--- a/libs/update_breakpad_win.bat
+++ b/libs/update_breakpad_win.bat
@@ -1,0 +1,28 @@
+@echo off
+
+cd %~dp0
+
+if exist breakpad (
+  goto update_gclient
+)
+
+:install_breakpad
+echo Installing Breakpad for the first time
+
+mkdir breakpad
+pushd breakpad
+call fetch.bat breakpad
+
+if errorlevel 1 (
+  echo Working around breakpad bug on Windows
+  python3.bat src\src\tools\python\deps-to-manifest.py src/DEPS src/default.xml
+)
+
+popd
+
+:update_gclient
+pushd breakpad
+call gclient.bat sync
+popd
+
+EXIT /B


### PR DESCRIPTION
Breakpad updated to Python3 and this appears to have broken Google depot_tools fetch.bat and gclient.bat on Windows.
Sadly, updating depot_tools alone was not enough!

Work around the issue by:

- Move the Windows breakpad setup into a batch file to catch the return code.
- Manually call the Python script named in the DEPS hook if it fails.
- Allow the `gclient.bat sync` call to fail without aborting the build

This workaround can be removed once upstream fixes the issue.