### PR TITLE
Qt >= 6.10 fixes

### DIFF
--- a/src/sacn/sacneffectengine.h
+++ b/src/sacn/sacneffectengine.h
@@ -17,6 +17,7 @@
 #define SACNEFFECTENGINE_H
 
 #include "sacnsender.h"
+#include <QElapsedTimer>
 #include <QImage>
 #include <QObject>
 #include <QPixmap>


### PR DESCRIPTION
Fixes #367.

Qt 6.10 is (at time of writing) the Qt version included with Fedora Linux.