### PR TITLE
Fix crash when closing Multi-Universe Transmit

### DIFF
--- a/src/ui/multiuniverse.cpp
+++ b/src/ui/multiuniverse.cpp
@@ -21,6 +21,7 @@
 #include "preferences.h"
 #include "sacneffectengine.h"
 #include <QCheckBox>
+#include <QCloseEvent>
 #include <QComboBox>
 #include <QLabel>
 #include <QMutableListIterator>
@@ -175,6 +176,15 @@ void MultiUniverse::addSource(
 
     QTableWidgetItem * item = new QTableWidgetItem(sender->name());
     ui->tableWidget->setItem(row, COL_NAME, item);
+}
+
+void MultiUniverse::closeEvent(QCloseEvent * event)
+{
+    QWidget::closeEvent(event);
+    if (event->isAccepted())
+    {
+        ui->tableWidget->clear();
+    }
 }
 
 void MultiUniverse::on_btnAddRow_pressed()

--- a/src/ui/multiuniverse.h
+++ b/src/ui/multiuniverse.h
@@ -36,6 +36,11 @@ public:
 
     explicit MultiUniverse(int firstUniverse = MIN_SACN_UNIVERSE, QWidget * parent = 0);
     ~MultiUniverse();
+
+protected:
+
+    void closeEvent(QCloseEvent * event) override;
+
 private slots:
     void on_btnAddRow_pressed();
     void on_btnRemoveRow_pressed();


### PR DESCRIPTION
Fixes #373.

Crash caused by the config widgets in each universe's row calling `removeWidgetFromIndex` after the window's destructor has run. Fixed by cleaning up the UI in `closeEvent` so signals meet their slots before destructor runs.