### PR TITLE
Correct data type for address in UniverseView::prioText

### DIFF
--- a/src/ui/universeview.cpp
+++ b/src/ui/universeview.cpp
@@ -265,17 +265,25 @@ void UniverseView::resizeColumns()
     ui->tableView->setColumnWidth(SACNSourceTableModel::COL_NAME, width - used - 5);
 }
 
-QString UniverseView::prioText(const sACNSource * source, quint8 address) const
+QString UniverseView::prioText(const sACNSource * source, int address) const
 {
     if (source == nullptr) return tr("Unknown");
 
     if (source->doing_per_channel)
+    {
         if (source->priority_array[address] > 0)
+        {
             return QString::number(source->priority_array[address]);
+        }
         else
+        {
             return tr("Unpatched");
+        }
+    }
     else
+    {
         return QString::number(source->priority);
+    }
 }
 
 void UniverseView::selectedAddressChanged(int address)

--- a/src/ui/universeview.h
+++ b/src/ui/universeview.h
@@ -81,7 +81,7 @@ private:
 
     void updateButtons(bool running);
 
-    QString prioText(const sACNSource * source, quint8 address) const;
+    QString prioText(const sACNSource * source, int address) const;
 
     Ui::UniverseView * ui = nullptr;
     SACNSourceTableModel * m_sourceTableModel = nullptr;


### PR DESCRIPTION
Fixes #375.

`UniverseView::prioText()` was using an 8-bit unsigned for the address, meaning it would get priority information for (sACN Address - 1) % 256. Change it to an int to match what's used elsewhere.

FWIW this was only a problem in the info display that shows all levels for the selected address, not in the grid display.